### PR TITLE
Fix #25: Add create_or_update_file tool

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -12,6 +12,8 @@ import {
   createDryRunCommentTool,
   createDryRunBranchTool,
   createDryRunPullRequestTool,
+  createOrUpdateFileTool,
+  createDryRunCreateOrUpdateFileTool,
   ToolCallCounter,
   wrapWithCircuitBreaker,
 } from './github-tools.js';
@@ -36,6 +38,7 @@ export function createDeepAgentWithGitHub(config: Config, options: { maxIssues?:
   let commentTool = options.dryRun ? createDryRunCommentTool() : createCommentOnIssueTool(owner, repo, octokit);
   let branchTool = options.dryRun ? createDryRunBranchTool() : createBranchTool(owner, repo, octokit);
   let prTool = options.dryRun ? createDryRunPullRequestTool() : createPullRequestTool(owner, repo, octokit);
+  let commitFileTool = options.dryRun ? createDryRunCreateOrUpdateFileTool() : createOrUpdateFileTool(owner, repo, octokit);
 
   // Circuit breaker: wrap all tools with a shared call counter
   if (options.maxToolCalls) {
@@ -46,6 +49,7 @@ export function createDeepAgentWithGitHub(config: Config, options: { maxIssues?:
     commentTool = wrapWithCircuitBreaker(commentTool, counter);
     branchTool = wrapWithCircuitBreaker(branchTool, counter);
     prTool = wrapWithCircuitBreaker(prTool, counter);
+    commitFileTool = wrapWithCircuitBreaker(commitFileTool, counter);
   }
 
   // System prompt - full workflow instructions
@@ -75,7 +79,14 @@ When given issues to analyze, follow this workflow for EACH issue:
    - Use create_branch with name: issue-<number>-<short-description>
    - Use lowercase, hyphens for spaces, keep it short but descriptive
 
-5. OPEN a draft PR:
+5. COMMIT proposed changes to the branch:
+   - Use create_or_update_file to write your proposed fix to the feature branch
+   - Each call commits one file. Make multiple calls for multi-file changes.
+   - Write the FULL file content (not a diff) — the tool replaces the entire file
+   - Use clear commit messages like "Fix #<number>: improve README structure"
+   - You MUST commit at least one file so the PR has a real diff
+
+6. OPEN a draft PR:
    - Use create_pull_request with:
      - title: "Fix #<number>: <short description>"
      - body: Include "Closes #<number>" on its own line, plus your analysis summary
@@ -83,11 +94,11 @@ When given issues to analyze, follow this workflow for EACH issue:
    - This links the PR to the issue automatically
 
 IMPORTANT:
-- Always create the branch BEFORE the PR (the PR needs the branch to exist)
+- Always create the branch BEFORE committing files, and commit files BEFORE the PR
 - Use write_todos at the start to plan your approach for all issues
-- Process issues one at a time, completing all 5 steps before moving to the next
+- Process issues one at a time, completing all 6 steps before moving to the next
 - Never merge PRs -- always open them as drafts
-- Write tools (comment, branch, PR) are idempotent. If they return { skipped: true }, the work was already done -- move to the next step without retrying
+- Write tools (comment, branch, PR, create_or_update_file) are idempotent. If they return { skipped: true }, the work was already done -- move to the next step without retrying
 
 Available tools:
 - fetch_github_issues: Fetch issues from the repo (supports 'since' for polling)
@@ -95,6 +106,7 @@ Available tools:
 - read_repo_file: Read a single file's contents from the repo
 - comment_on_issue: Post a comment on a GitHub issue
 - create_branch: Create a new branch in the repo
+- create_or_update_file: Commit a file to a branch (creates one commit per call)
 - create_pull_request: Open a draft PR
 - write_file: Write analysis files to ./issues/
 - read_file: Read local files
@@ -104,7 +116,7 @@ Available tools:
   // Create the agent
   const agent = createDeepAgent({
     model,
-    tools: [githubIssuesTool, listFilesTool, readFileTool, commentTool, branchTool, prTool],
+    tools: [githubIssuesTool, listFilesTool, readFileTool, commentTool, branchTool, commitFileTool, prTool],
     systemPrompt,
   });
 

--- a/src/github-tools.ts
+++ b/src/github-tools.ts
@@ -470,6 +470,68 @@ export function createReadRepoFileTool(owner: string, repo: string, octokit: Oct
   );
 }
 
+/**
+ * Tool: Create or update a file on a branch via the GitHub API
+ * Uses octokit.rest.repos.createOrUpdateFileContents() to commit a single file.
+ * If the file already exists, its current SHA is required (fetched automatically).
+ */
+export function createOrUpdateFileTool(owner: string, repo: string, octokit: Octokit) {
+  return tool(
+    async ({ path, content, message, branch }: { path: string; content: string; message: string; branch: string }) => {
+      try {
+        console.log(`📝 Committing ${path} to ${branch} in ${owner}/${repo}...`);
+
+        // Check if file already exists to get its SHA (needed for updates)
+        let existingSha: string | undefined;
+        try {
+          const { data } = await octokit.rest.repos.getContent({
+            owner,
+            repo,
+            path,
+            ref: branch,
+          });
+          if (!Array.isArray(data) && data.type === 'file') {
+            existingSha = data.sha;
+          }
+        } catch (e: unknown) {
+          const status = (e as { status?: number }).status;
+          if (status !== 404) throw e;
+          // 404 = file doesn't exist yet, that's fine (create mode)
+        }
+
+        const { data: result } = await octokit.rest.repos.createOrUpdateFileContents({
+          owner,
+          repo,
+          path,
+          message,
+          content: Buffer.from(content).toString('base64'),
+          branch,
+          ...(existingSha ? { sha: existingSha } : {}),
+        });
+
+        return JSON.stringify({
+          path,
+          sha: result.content?.sha,
+          commit_sha: result.commit.sha,
+          html_url: result.content?.html_url,
+        });
+      } catch (error) {
+        return `Error committing file '${path}': ${error}`;
+      }
+    },
+    {
+      name: 'create_or_update_file',
+      description: 'Create or update a file on a branch via the GitHub API. Each call creates one commit. Use this to push proposed code changes to a feature branch before opening a PR.',
+      schema: z.object({
+        path: z.string().describe('File path in the repo (e.g., "README.md", "src/utils.ts")'),
+        content: z.string().describe('The full file content to write'),
+        message: z.string().describe('Git commit message for this change'),
+        branch: z.string().describe('The branch to commit to (e.g., "issue-1-improve-readme")'),
+      }),
+    }
+  );
+}
+
 // ── Dry-run wrappers ────────────────────────────────────────────────────────
 // These create replacement tools with the same name/schema as the real ones
 // but log what they WOULD do and return fake success results.
@@ -539,6 +601,32 @@ export function createDryRunPullRequestTool() {
         body: z.string().describe('PR description'),
         head: z.string().describe('The branch containing changes'),
         base: z.string().optional().default('main').describe('The branch to merge into (default: main)'),
+      }),
+    }
+  );
+}
+
+export function createDryRunCreateOrUpdateFileTool() {
+  return tool(
+    async ({ path, content, message, branch }: { path: string; content: string; message: string; branch: string }) => {
+      const preview = content.length > 80 ? content.slice(0, 80) + '...' : content;
+      console.log(`DRY RUN -- would commit ${path} to ${branch}: ${preview}`);
+      return JSON.stringify({
+        dry_run: true,
+        path,
+        sha: '0000000000000000000000000000000000000000',
+        commit_sha: '0000000000000000000000000000000000000000',
+        html_url: `(dry-run) ${path} on ${branch}`,
+      });
+    },
+    {
+      name: 'create_or_update_file',
+      description: 'Create or update a file on a branch. (DRY RUN MODE: will log but not execute)',
+      schema: z.object({
+        path: z.string().describe('File path in the repo'),
+        content: z.string().describe('The full file content to write'),
+        message: z.string().describe('Git commit message'),
+        branch: z.string().describe('The branch to commit to'),
       }),
     }
   );


### PR DESCRIPTION
## Summary
- Adds `create_or_update_file` tool using GitHub Contents API (`repos.createOrUpdateFileContents`)
- Adds corresponding dry-run stub
- Wires into agent with circuit breaker support
- Updates system prompt with new step 5: commit files to branch before opening PR

The agent previously created branches and PRs but never committed any files, so all PRs were empty (no diff). Now the agent can push proposed code changes to feature branches.

Closes #25

## Test plan
- [x] `pnpm start --dry-run` — verifies imports and dry-run stub
- [ ] `pnpm start` — full run against a repo with an open issue to verify file commits appear in the PR