### PR TITLE
Fix #27: Add self-review step to catch hallucinated code

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -86,19 +86,40 @@ When given issues to analyze, follow this workflow for EACH issue:
    - Use clear commit messages like "Fix #<number>: improve README structure"
    - You MUST commit at least one file so the PR has a real diff
 
-6. OPEN a draft PR:
+6. SELF-REVIEW your committed changes:
+   - Use read_repo_file to read back each file you committed (from the feature branch)
+   - Compare against the original file from main that you read in step 1
+   - Check for these problems:
+     a. Invented imports — modules or packages not in package.json or the codebase
+     b. Non-existent functions — calling functions that don't exist in the repo
+     c. Fabricated APIs — endpoints, methods, or interfaces you never saw in the code
+     d. New dependencies — adding require/import for libraries not already used
+     e. Wrong patterns — using patterns inconsistent with the existing code style
+   - If you find ANY of these problems, commit a corrected version that removes them
+   - If the fix is beyond what you can confidently produce from the code you've read,
+     remove the code changes and note "needs human implementation" in the PR body
+   - Add a "## Self-Review" section to your PR body noting what you checked
+
+7. OPEN a draft PR:
    - Use create_pull_request with:
      - title: "Fix #<number>: <short description>"
-     - body: Include "Closes #<number>" on its own line, plus your analysis summary
+     - body: Include "Closes #<number>" on its own line, plus your analysis summary and self-review notes
      - head: the branch you just created
    - This links the PR to the issue automatically
 
 IMPORTANT:
 - Always create the branch BEFORE committing files, and commit files BEFORE the PR
 - Use write_todos at the start to plan your approach for all issues
-- Process issues one at a time, completing all 6 steps before moving to the next
+- Process issues one at a time, completing all 7 steps before moving to the next
 - Never merge PRs -- always open them as drafts
 - Write tools (comment, branch, PR, create_or_update_file) are idempotent. If they return { skipped: true }, the work was already done -- move to the next step without retrying
+
+CODE GROUNDING RULES:
+- ONLY use imports, functions, and patterns that already exist in the codebase
+- NEVER add new dependencies or libraries
+- NEVER invent APIs, endpoints, or interfaces you haven't seen in the code
+- When modifying a file, base your changes on the EXACT content from read_repo_file
+- If you're unsure how something works, document it in the PR instead of guessing
 
 Available tools:
 - fetch_github_issues: Fetch issues from the repo (supports 'since' for polling)


### PR DESCRIPTION
## Summary
- Adds **step 6 (self-review)** to the agent's 7-step workflow
- Agent reads back committed files, compares against originals from main
- Checks for: invented imports, non-existent functions, fabricated APIs, new dependencies, wrong patterns
- If hallucinations found → commits corrected version or flags "needs human implementation"
- Adds **CODE GROUNDING RULES** anchoring the agent to existing codebase patterns

## Workflow (before → after)
- Before: analyze → comment → document → branch → commit → PR (6 steps)
- After: analyze → comment → document → branch → commit → **self-review** → PR (7 steps)

Closes #27

## Test plan
- [ ] Run `pnpm start` against a repo with an open issue
- [ ] Verify agent reads back committed files before opening PR
- [ ] Verify PR body includes "## Self-Review" section