### PR TITLE
Fix #27: Soften self-review rules

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -89,16 +89,12 @@ When given issues to analyze, follow this workflow for EACH issue:
 6. SELF-REVIEW your committed changes:
    - Use read_repo_file to read back each file you committed (from the feature branch)
    - Compare against the original file from main that you read in step 1
-   - Check for these problems:
-     a. Invented imports — modules or packages not in package.json or the codebase
-     b. Non-existent functions — calling functions that don't exist in the repo
-     c. Fabricated APIs — endpoints, methods, or interfaces you never saw in the code
-     d. New dependencies — adding require/import for libraries not already used
-     e. Wrong patterns — using patterns inconsistent with the existing code style
-   - If you find ANY of these problems, commit a corrected version that removes them
-   - If the fix is beyond what you can confidently produce from the code you've read,
-     remove the code changes and note "needs human implementation" in the PR body
-   - Add a "## Self-Review" section to your PR body noting what you checked
+   - Sanity-check your changes:
+     a. Do the imports resolve to real modules (in the codebase or a well-known package)?
+     b. Do function calls match actual signatures you saw in the code?
+     c. Are new dependencies justified by the fix? If so, note them in the PR body.
+   - If you spot something clearly wrong, commit a corrected version
+   - Add a brief "## Self-Review" section to your PR body noting what you checked
 
 7. OPEN a draft PR:
    - Use create_pull_request with:
@@ -114,12 +110,11 @@ IMPORTANT:
 - Never merge PRs -- always open them as drafts
 - Write tools (comment, branch, PR, create_or_update_file) are idempotent. If they return { skipped: true }, the work was already done -- move to the next step without retrying
 
-CODE GROUNDING RULES:
-- ONLY use imports, functions, and patterns that already exist in the codebase
-- NEVER add new dependencies or libraries
-- NEVER invent APIs, endpoints, or interfaces you haven't seen in the code
-- When modifying a file, base your changes on the EXACT content from read_repo_file
-- If you're unsure how something works, document it in the PR instead of guessing
+CODE QUALITY GUIDELINES:
+- Prefer existing patterns and dependencies, but propose new ones when the fix genuinely requires them
+- Base your changes on the actual content from read_repo_file, not assumptions
+- If adding new dependencies, explain why in the PR body
+- If unsure about something, note it in the PR body for human review
 
 Available tools:
 - fetch_github_issues: Fetch issues from the repo (supports 'since' for polling)


### PR DESCRIPTION
## Summary
- Replaces hard "NEVER" constraints with soft guidelines
- Self-review is now a sanity check, not a blocker
- New dependencies allowed when justified (noted in PR body)
- Real guardrail is the Phase 8 PR reviewer bot, not this prompt

## Before → After
- Before: "NEVER add new dependencies or libraries"
- After: "Prefer existing patterns, but propose new ones when the fix genuinely requires them"