### PR TITLE
Fix #33: Add structured logging for tool calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@
 
 ---
 
+## v0.3.3 — 2026-02-08
+
+### Added
+- **Structured logging for tool calls** (Issue #33) — every tool invocation logs name, arguments, timing, and circuit breaker headroom
+- New `src/logger.ts` with `wrapWithLogging()` composable wrapper function
+- Log format: `[HH:MM:SS] TOOL #N/M | tool_name | { args } | Xms`
+- Errors logged to stderr with context before re-throwing
+- 9 new unit tests in `tests/logger.test.ts`
+
+### Changed
+- `src/agent.ts` applies logging wrapper as outermost layer on all 7 tools
+- `src/triage-agent.ts` applies logging wrapper on all 3 read-only tools
+
+---
+
 ## v0.3.2 — 2026-02-08
 
 ### Added

--- a/LEARNING_LOG.md
+++ b/LEARNING_LOG.md
@@ -4272,3 +4272,50 @@ This does not block the merge because the triage agent itself works correctly in
 **Recommendation to team lead:** Merge is safe -- the triage agent is a standalone component that works correctly. The handoff gap should be tracked as a known limitation and addressed in Issue #4. A `// TODO(Issue #4)` comment in `core.ts` at the analysis phase boundary would make this explicit.
 
 ---
+
+## Entry 29: Composable Middleware -- Structured Logging via Tool Wrapping (Issue #33)
+
+**Date:** 2026-02-08
+**Author:** Builder Agent
+**Builds on:** Entry 20 (Circuit Breaker), Entry 24 (Two-Phase Pipeline)
+
+### What just happened?
+
+We added structured logging for every tool call. Each invocation now logs:
+- Timestamp (HH:MM:SS)
+- Running tool count and circuit breaker headroom (e.g., `#7/30`)
+- Tool name
+- Arguments (compact JSON)
+- Duration in milliseconds
+
+Errors are logged to `console.error` with the same format plus the error message, then re-thrown so the circuit breaker and agent framework can handle them normally.
+
+### Why this design: Composable middleware via `wrapWithLogging()`
+
+The key pattern here is **composable tool wrappers** -- small functions that each add one behavior by wrapping `tool.invoke()`. The tool wrapping stack is now:
+
+```
+LLM calls tool.invoke(input)
+  -> wrapWithLogging    (outermost: logs args, timing, errors)
+    -> wrapWithCircuitBreaker  (increments counter, may throw)
+      -> original tool.invoke  (actual API call)
+```
+
+This is the middleware/decorator pattern applied to LangChain tools. Each wrapper:
+1. Takes a tool and returns the same tool with a modified `.invoke()`
+2. Does not know about the other wrappers
+3. Can be applied in any order (though order matters for semantics)
+
+**Why logging is the outermost layer:** If logging wrapped inside the circuit breaker, a breaker trip would prevent the log from being written. By placing logging outside, we see the attempted call and the error in the log even when the breaker trips.
+
+**Why a separate `src/logger.ts` file:** The circuit breaker lives in `github-tools.ts` because it was the first wrapper and was tightly coupled to tool creation. But as more wrappers accumulate (logging, retry, rate limiting), keeping them in the tools file creates coupling between unrelated concerns. A separate file per wrapper keeps each composable unit independent. The retry wrapper (Issue #17) should follow the same pattern.
+
+### The `ToolCallCounter` as a read-only dependency
+
+The logging wrapper accepts an optional `ToolCallCounter` to display headroom (`#7/30`). It reads the counter but never increments it -- incrementing is the circuit breaker's job. This avoids double-counting and keeps responsibilities clear: the counter has one writer (circuit breaker) and one reader (logger).
+
+### What NOT to log
+
+The issue explicitly calls out that tool **responses** should not be logged. For tools like `read_repo_file`, the response is an entire file's contents -- logging it would flood the terminal and duplicate data that is already visible in the LLM's context. Arguments are small (a file path, a branch name), so they provide useful debugging context without volume.
+
+---

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -17,6 +17,7 @@ import {
   ToolCallCounter,
   wrapWithCircuitBreaker,
 } from './github-tools.js';
+import { wrapWithLogging } from './logger.js';
 
 /**
  * Create the Deep Agent with GitHub integration
@@ -41,8 +42,8 @@ export function createDeepAgentWithGitHub(config: Config, options: { maxIssues?:
   let commitFileTool = options.dryRun ? createDryRunCreateOrUpdateFileTool() : createOrUpdateFileTool(owner, repo, octokit);
 
   // Circuit breaker: wrap all tools with a shared call counter
-  if (options.maxToolCalls) {
-    const counter = new ToolCallCounter(options.maxToolCalls);
+  const counter = options.maxToolCalls ? new ToolCallCounter(options.maxToolCalls) : undefined;
+  if (counter) {
     githubIssuesTool = wrapWithCircuitBreaker(githubIssuesTool, counter);
     listFilesTool = wrapWithCircuitBreaker(listFilesTool, counter);
     readFileTool = wrapWithCircuitBreaker(readFileTool, counter);
@@ -51,6 +52,15 @@ export function createDeepAgentWithGitHub(config: Config, options: { maxIssues?:
     prTool = wrapWithCircuitBreaker(prTool, counter);
     commitFileTool = wrapWithCircuitBreaker(commitFileTool, counter);
   }
+
+  // Structured logging: wrap all tools (outermost layer, logs even on breaker trip)
+  githubIssuesTool = wrapWithLogging(githubIssuesTool, counter);
+  listFilesTool = wrapWithLogging(listFilesTool, counter);
+  readFileTool = wrapWithLogging(readFileTool, counter);
+  commentTool = wrapWithLogging(commentTool, counter);
+  branchTool = wrapWithLogging(branchTool, counter);
+  prTool = wrapWithLogging(prTool, counter);
+  commitFileTool = wrapWithLogging(commitFileTool, counter);
 
   // System prompt - full workflow instructions
   const systemPrompt = `You are a GitHub issue analysis agent for the repository ${owner}/${repo}.

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,0 +1,63 @@
+import { tool } from 'langchain';
+import type { ToolCallCounter } from './github-tools.js';
+
+/**
+ * Format a timestamp as HH:MM:SS for log output.
+ */
+function formatTime(date: Date): string {
+  return date.toTimeString().slice(0, 8);
+}
+
+/**
+ * Wrap a LangChain tool with structured logging.
+ *
+ * Logs: timestamp, running tool count / limit, tool name, arguments, and duration.
+ * Follows the same wrapping pattern as wrapWithCircuitBreaker.
+ *
+ * If a ToolCallCounter is provided, the log shows "TOOL #N/M" headroom.
+ * If not, the log shows "TOOL" without a count.
+ *
+ * Errors are logged with context before being returned to the LLM.
+ * Tool responses are NOT logged (they are too large and verbose).
+ */
+export function wrapWithLogging<T extends ReturnType<typeof tool>>(
+  wrappedTool: T,
+  counter?: ToolCallCounter,
+): T {
+  const originalInvoke = wrappedTool.invoke.bind(wrappedTool);
+
+  wrappedTool.invoke = async (input: any, options?: any) => {
+    const start = performance.now();
+    const timestamp = formatTime(new Date());
+
+    // Build the count label: "#7/30" if counter is available, empty otherwise
+    const countLabel = counter
+      ? ` #${counter.getCount() + 1}/${counter.limit}`
+      : '';
+
+    // Stringify the arguments (compact, single line)
+    let argsStr: string;
+    try {
+      argsStr = JSON.stringify(input);
+    } catch {
+      argsStr = String(input);
+    }
+
+    try {
+      const result = await originalInvoke(input, options);
+      const durationMs = Math.round(performance.now() - start);
+      console.log(
+        `[${timestamp}] TOOL${countLabel} | ${wrappedTool.name} | ${argsStr} | ${durationMs}ms`,
+      );
+      return result;
+    } catch (error) {
+      const durationMs = Math.round(performance.now() - start);
+      console.error(
+        `[${timestamp}] TOOL${countLabel} | ${wrappedTool.name} | ${argsStr} | ${durationMs}ms | ERROR: ${error}`,
+      );
+      throw error;
+    }
+  };
+
+  return wrappedTool;
+}

--- a/src/triage-agent.ts
+++ b/src/triage-agent.ts
@@ -9,6 +9,7 @@ import {
   ToolCallCounter,
   wrapWithCircuitBreaker,
 } from './github-tools.js';
+import { wrapWithLogging } from './logger.js';
 
 // ── Triage output interface ─────────────────────────────────────────────────
 
@@ -126,6 +127,11 @@ export function createTriageAgent(config: Config, options: { maxToolCalls?: numb
   githubIssuesTool = wrapWithCircuitBreaker(githubIssuesTool, counter);
   listFilesTool = wrapWithCircuitBreaker(listFilesTool, counter);
   readFileTool = wrapWithCircuitBreaker(readFileTool, counter);
+
+  // Structured logging (outermost layer)
+  githubIssuesTool = wrapWithLogging(githubIssuesTool, counter);
+  listFilesTool = wrapWithLogging(listFilesTool, counter);
+  readFileTool = wrapWithLogging(readFileTool, counter);
 
   const systemPrompt = buildTriageSystemPrompt(owner, repo);
 

--- a/tests/logger.test.ts
+++ b/tests/logger.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { wrapWithLogging } from '../src/logger.js';
+import {
+  createDryRunBranchTool,
+  createDryRunCommentTool,
+  ToolCallCounter,
+} from '../src/github-tools.js';
+
+// ── wrapWithLogging ──────────────────────────────────────────────────────────
+
+describe('wrapWithLogging', () => {
+  let consoleSpy: ReturnType<typeof vi.spyOn>;
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleSpy.mockRestore();
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('logs tool name, arguments, and duration on success', async () => {
+    const tool = wrapWithLogging(createDryRunBranchTool());
+
+    await tool.invoke({ branch_name: 'issue-1-fix' });
+
+    expect(consoleSpy).toHaveBeenCalledTimes(2); // dry-run tool logs + our log
+    const logCalls = consoleSpy.mock.calls.map((c) => c[0]);
+    const ourLog = logCalls.find((msg: string) => msg.includes('TOOL'));
+    expect(ourLog).toBeDefined();
+    expect(ourLog).toContain('create_branch');
+    expect(ourLog).toContain('issue-1-fix');
+    expect(ourLog).toMatch(/\d+ms/);
+  });
+
+  it('includes count label when ToolCallCounter is provided', async () => {
+    const counter = new ToolCallCounter(10);
+    const tool = wrapWithLogging(createDryRunBranchTool(), counter);
+
+    await tool.invoke({ branch_name: 'test-branch' });
+
+    const logCalls = consoleSpy.mock.calls.map((c) => c[0]);
+    const ourLog = logCalls.find((msg: string) => msg.includes('TOOL'));
+    expect(ourLog).toContain('#1/10');
+  });
+
+  it('omits count label when no counter is provided', async () => {
+    const tool = wrapWithLogging(createDryRunBranchTool());
+
+    await tool.invoke({ branch_name: 'test-branch' });
+
+    const logCalls = consoleSpy.mock.calls.map((c) => c[0]);
+    const ourLog = logCalls.find((msg: string) => msg.includes('TOOL'));
+    // Should have "TOOL |" without a count
+    expect(ourLog).toMatch(/TOOL \|/);
+    expect(ourLog).not.toMatch(/#\d+\/\d+/);
+  });
+
+  it('increments count label on successive calls', async () => {
+    const counter = new ToolCallCounter(10);
+    const tool = wrapWithLogging(createDryRunBranchTool(), counter);
+
+    // Note: counter is not wrapped with circuit breaker, so it won't increment on its own.
+    // wrapWithLogging reads the counter but does NOT increment it.
+    // In production, the circuit breaker wrapper increments the counter.
+    // For this test, we manually increment to simulate.
+    counter.increment('create_branch');
+    await tool.invoke({ branch_name: 'first' });
+
+    const logCalls = consoleSpy.mock.calls.map((c) => c[0]);
+    const ourLog = logCalls.find((msg: string) => msg.includes('TOOL'));
+    // After 1 manual increment, getCount() = 1, so next label = #2/10
+    expect(ourLog).toContain('#2/10');
+  });
+
+  it('logs errors to console.error and re-throws', async () => {
+    const tool = createDryRunBranchTool();
+    const originalInvoke = tool.invoke.bind(tool);
+
+    // Make the tool throw
+    tool.invoke = async () => {
+      throw new Error('API exploded');
+    };
+
+    const logged = wrapWithLogging(tool);
+
+    await expect(logged.invoke({ branch_name: 'err' })).rejects.toThrow('API exploded');
+    expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
+    const errLog = consoleErrorSpy.mock.calls[0][0];
+    expect(errLog).toContain('ERROR');
+    expect(errLog).toContain('API exploded');
+    expect(errLog).toContain('create_branch');
+
+    // Restore for other tests
+    tool.invoke = originalInvoke;
+  });
+
+  it('includes timestamp in HH:MM:SS format', async () => {
+    const tool = wrapWithLogging(createDryRunCommentTool());
+
+    await tool.invoke({ issue_number: 5, body: 'test' });
+
+    const logCalls = consoleSpy.mock.calls.map((c) => c[0]);
+    const ourLog = logCalls.find((msg: string) => msg.includes('TOOL'));
+    // Match [HH:MM:SS] pattern
+    expect(ourLog).toMatch(/\[\d{2}:\d{2}:\d{2}\]/);
+  });
+
+  it('preserves the tool name after wrapping', () => {
+    const tool = wrapWithLogging(createDryRunBranchTool());
+    expect(tool.name).toBe('create_branch');
+  });
+
+  it('returns the original tool result', async () => {
+    const tool = wrapWithLogging(createDryRunBranchTool());
+    const result = JSON.parse(await tool.invoke({ branch_name: 'test' }));
+
+    expect(result.dry_run).toBe(true);
+    expect(result.branch).toBe('test');
+  });
+
+  it('works with multiple tools sharing a counter', async () => {
+    const counter = new ToolCallCounter(20);
+    const branchTool = wrapWithLogging(createDryRunBranchTool(), counter);
+    const commentTool = wrapWithLogging(createDryRunCommentTool(), counter);
+
+    await branchTool.invoke({ branch_name: 'b1' });
+    await commentTool.invoke({ issue_number: 1, body: 'hi' });
+
+    const logCalls = consoleSpy.mock.calls.map((c) => c[0]);
+    const toolLogs = logCalls.filter((msg: string) => msg.includes('TOOL'));
+    // Both should show count out of 20
+    expect(toolLogs[0]).toContain('/20');
+    expect(toolLogs[1]).toContain('/20');
+  });
+});


### PR DESCRIPTION
Closes #33

## Summary

Adds composable `wrapWithLogging()` wrapper that logs every tool invocation with:
- Timestamp (`[HH:MM:SS]`)
- Running tool count and circuit breaker headroom (`TOOL #7/30`)
- Tool name and arguments (compact JSON)
- Execution duration (`342ms`)
- Errors logged to stderr with context before re-throwing

```
[12:34:56] TOOL #7/30 | read_repo_file | {"path":"src/server.ts","branch":"main"} | 342ms
[12:34:57] TOOL #8/30 | comment_on_issue | {"issue_number":3} | 1204ms
```

Tool responses are NOT logged (too verbose per issue spec).

## Changes

- **New:** `src/logger.ts` — `wrapWithLogging()` function following the same composable wrapper pattern as `wrapWithCircuitBreaker()`
- **New:** `tests/logger.test.ts` — 9 unit tests covering success logging, error logging, counter headroom, timestamp format, tool name preservation
- **Changed:** `src/agent.ts` — logging applied as outermost wrapper on all 7 tools
- **Changed:** `src/triage-agent.ts` — logging applied on all 3 read-only tools
- **Docs:** CHANGELOG.md v0.3.3 entry, LEARNING_LOG.md Entry 29 (composable middleware teaching note)

## Design Decisions

- **Logging is the outermost wrapper** so it captures circuit breaker trips in the error log
- **Counter is read-only** in the logger — incrementing is the circuit breaker's responsibility
- **Separate `src/logger.ts` file** rather than adding to `github-tools.ts` to avoid merge conflicts with Issue #17 (retry) builder
- **No changes to `github-tools.ts` tool function bodies** (hard constraint to avoid conflicts)

## Version Bump

Proposing v0.3.3 (patch bump per convention). CHANGELOG entry added. package.json bump deferred to merge to avoid conflicting with other parallel builders' changes.

## Test Plan

- [x] 9 new tests in `tests/logger.test.ts` — all passing
- [x] All 31 existing `github-tools.test.ts` tests still pass
- [x] All 19 `triage-agent.test.ts` tests still pass
- [x] 3 pre-existing failures in `core.test.ts` are unrelated (Issue #31 action tracking metadata changes)