### PR TITLE
Fix #31: Enrich action tracking with full response metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@
 
 ---
 
+## v0.3.4 — 2026-02-08
+
+### Changed
+- **Enriched action tracking metadata** (Issue #31) — `IssueActions` now stores full API response metadata instead of simple booleans
+- `comment` field: `{ id, html_url }` (was `commented: boolean`)
+- `branch` field: `{ name, sha }` (was `branch: string | null`)
+- `commits` field: `Array<{ path, sha, commit_sha }>` (new)
+- `pr` field: `{ number, html_url }` (was `pr: number | null`)
+- `extractIssueActions()` now correlates tool calls with responses using pending-state tracking
+- `migratePollState()` handles 3 format generations: pre-v0.2.10, v0.2.10 boolean, v0.3.4+ enriched
+- `buildUserMessage()` and `showStatus()` updated to use enriched field names
+- 12 new enriched metadata tests + existing tests updated — 56 in core.test.ts, 126 total
+
+---
+
 ## v0.3.2 — 2026-02-08
 
 ### Added

--- a/LEARNING_LOG.md
+++ b/LEARNING_LOG.md
@@ -4272,3 +4272,45 @@ This does not block the merge because the triage agent itself works correctly in
 **Recommendation to team lead:** Merge is safe -- the triage agent is a standalone component that works correctly. The handoff gap should be tracked as a known limitation and addressed in Issue #4. A `// TODO(Issue #4)` comment in `core.ts` at the analysis phase boundary would make this explicit.
 
 ---
+
+## Entry 28: Enriching Action Tracking -- State Schema Evolution (Issue #31)
+
+**Date:** 2026-02-08
+**Author:** Builder Agent (builder-31)
+**Scope:** `IssueActions` interface in `src/core.ts`, `extractIssueActions()`, `migratePollState()`, `buildUserMessage()`, `showStatus()`
+
+### Why This Design
+
+The original `IssueActions` tracked simple booleans (`commented: true`) and primitive values (`branch: string`, `pr: number`). This was enough to know *whether* an action happened but not enough to *retract* it. If the agent posts a bad comment, you need the comment ID to delete it. If it pushes a broken file, you need the file SHA to revert it.
+
+Enriched metadata solves this: each action now stores the full API response identifiers (IDs, SHAs, URLs) needed for future retraction workflows.
+
+### Key Design Decisions
+
+**1. Schema shape -- objects instead of scalars:**
+- `comment: { id: number; html_url: string } | null` (was `commented: boolean`)
+- `branch: { name: string; sha: string } | null` (was `branch: string | null`)
+- `commits: Array<{ path, sha, commit_sha }>` (new -- tracks every file committed)
+- `pr: { number: number; html_url: string } | null` (was `pr: number | null`)
+
+Null means "not done yet". An object means "done, here's the metadata".
+
+**2. Tool call / response correlation via pending state:**
+The agent's message history alternates: tool_call message, then tool_response message. `extractIssueActions` uses pending-state variables (`pendingCommentIssue`, `pendingBranchIssue`, etc.) to remember which tool call is awaiting a response. When the next message contains parseable JSON matching the expected response shape, the metadata is captured.
+
+**3. Three-generation migration:**
+`migratePollState()` handles:
+- Case 1: pre-v0.2.10 -- no `issues` field at all (creates stub enriched entries)
+- Case 2: v0.2.10 -- boolean format `{ commented, branch, pr }` (converts via `migrateActionEntry()`)
+- Case 3: v0.3.4+ -- enriched format (pass through)
+
+Detection uses `isOldActionFormat()` which checks `typeof entry.commented === 'boolean'`.
+
+**4. Backwards-compatible serialization:**
+The enriched format is a superset. Old consumers that don't understand the new fields will fail gracefully because the field names changed (`commented` -> `comment`). The migration path is one-way: old -> enriched.
+
+### What This Enables (Future)
+
+- **Retraction:** Delete comments by ID, revert files by SHA, close PRs by number
+- **Audit trail:** Full provenance of every action the agent took
+- **Resumption with context:** The agent knows exactly what was committed, not just that "a branch exists"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "deepagents-github-test",
-  "version": "0.3.2",
+  "version": "0.3.4",
   "description": "Simple test to learn Deep Agents workflow with GitHub issues",
   "type": "module",
   "bin": {

--- a/src/core.ts
+++ b/src/core.ts
@@ -9,11 +9,13 @@ import type { TriageOutput } from './triage-agent.js';
 /**
  * Per-issue action tracking. Records which workflow steps have been
  * completed so the agent can resume partially-processed issues.
+ * v0.3.4: enriched with full response metadata for retraction capability.
  */
 export interface IssueActions {
-  commented: boolean;
-  branch: string | null;
-  pr: number | null;
+  comment: { id: number; html_url: string } | null;
+  branch: { name: string; sha: string } | null;
+  commits: Array<{ path: string; sha: string; commit_sha: string }>;
+  pr: { number: number; html_url: string } | null;
 }
 
 /**
@@ -49,24 +51,60 @@ export function loadPollState(): PollState | null {
 }
 
 /**
- * Migrate old poll state format (no `issues` field) to new format.
- * Old format: { lastPollTimestamp, lastPollIssueNumbers }
- * New format: adds `issues` record with empty actions for each known issue.
+ * Check if an issue actions entry uses the old v0.2.10 boolean format.
+ */
+function isOldActionFormat(entry: any): boolean {
+  return typeof entry.commented === 'boolean';
+}
+
+/**
+ * Migrate a single v0.2.10 boolean action entry to the enriched format.
+ */
+function migrateActionEntry(old: any): IssueActions {
+  return {
+    comment: old.commented ? { id: 0, html_url: '' } : null,
+    branch: old.branch ? { name: old.branch, sha: '' } : null,
+    commits: [],
+    pr: (old.pr !== null && old.pr > 0) ? { number: old.pr, html_url: '' } : null,
+  };
+}
+
+/**
+ * Migrate poll state across 3 format generations:
+ *   Case 1: pre-v0.2.10 — no `issues` field at all
+ *   Case 2: v0.2.10 — `issues` with boolean format { commented, branch, pr }
+ *   Case 3: v0.3.4+ — enriched format { comment, branch, commits, pr }
  */
 export function migratePollState(raw: any): PollState {
-  if (raw.issues) return raw as PollState;
-
-  // Old format: create stub action records for known issue numbers
-  const issues: Record<string, IssueActions> = {};
-  for (const num of raw.lastPollIssueNumbers ?? []) {
-    issues[String(num)] = { commented: true, branch: null, pr: null };
+  // Case 1: pre-v0.2.10 — no issues field
+  if (!raw.issues) {
+    const issues: Record<string, IssueActions> = {};
+    for (const num of raw.lastPollIssueNumbers ?? []) {
+      issues[String(num)] = { comment: { id: 0, html_url: '' }, branch: null, commits: [], pr: null };
+    }
+    return {
+      lastPollTimestamp: raw.lastPollTimestamp,
+      lastPollIssueNumbers: raw.lastPollIssueNumbers ?? [],
+      issues,
+    };
   }
 
-  return {
-    lastPollTimestamp: raw.lastPollTimestamp,
-    lastPollIssueNumbers: raw.lastPollIssueNumbers ?? [],
-    issues,
-  };
+  // Case 2: v0.2.10 boolean format
+  const entries = Object.values(raw.issues);
+  if (entries.length > 0 && isOldActionFormat(entries[0])) {
+    const migrated: Record<string, IssueActions> = {};
+    for (const [num, entry] of Object.entries(raw.issues)) {
+      migrated[num] = migrateActionEntry(entry);
+    }
+    return {
+      lastPollTimestamp: raw.lastPollTimestamp,
+      lastPollIssueNumbers: raw.lastPollIssueNumbers ?? [],
+      issues: migrated,
+    };
+  }
+
+  // Case 3: already enriched format
+  return raw as PollState;
 }
 
 export function savePollState(state: PollState): void {
@@ -104,8 +142,8 @@ export function extractProcessedIssues(
 
 /**
  * Extract per-issue action tracking from the agent's conversation messages.
- * Scans tool calls for comment, branch, and PR operations and records
- * which issues they targeted.
+ * Correlates tool calls with their responses to capture full metadata
+ * (comment IDs, branch SHAs, file SHAs, PR numbers/URLs).
  */
 export function extractIssueActions(
   messages: Array<{ tool_calls?: Array<{ name?: string; args?: Record<string, unknown> }>; content?: unknown }>,
@@ -113,56 +151,104 @@ export function extractIssueActions(
 ): Record<string, IssueActions> {
   const actions: Record<string, IssueActions> = { ...existing };
 
-  // Helper to ensure an entry exists for an issue
   function ensureEntry(issueNum: string): IssueActions {
     if (!actions[issueNum]) {
-      actions[issueNum] = { commented: false, branch: null, pr: null };
+      actions[issueNum] = { comment: null, branch: null, commits: [], pr: null };
     }
     return actions[issueNum];
   }
 
+  let pendingCommentIssue: string | null = null;
+  let pendingBranchIssue: string | null = null;
+  let pendingBranchName: string | null = null;
+  let pendingCommitIssue: string | null = null;
+  let pendingPrIssue: string | null = null;
+
   for (const msg of messages) {
-    if (!msg.tool_calls) continue;
-    for (const call of msg.tool_calls) {
-      const args = call.args ?? {};
+    if (msg.tool_calls) {
+      for (const call of msg.tool_calls) {
+        const args = call.args ?? {};
 
-      if (call.name === 'comment_on_issue' && args.issue_number) {
-        const entry = ensureEntry(String(args.issue_number));
-        entry.commented = true;
-      }
-
-      if (call.name === 'create_branch' && args.branch_name) {
-        // Try to extract issue number from branch name pattern: issue-<N>-...
-        const branchMatch = String(args.branch_name).match(/^issue-(\d+)/);
-        if (branchMatch) {
-          const entry = ensureEntry(branchMatch[1]);
-          entry.branch = String(args.branch_name);
+        if (call.name === 'comment_on_issue' && args.issue_number) {
+          pendingCommentIssue = String(args.issue_number);
+          ensureEntry(pendingCommentIssue);
         }
-      }
 
-      if (call.name === 'create_pull_request' && args.head) {
-        // Try to extract issue number from head branch pattern
-        const headMatch = String(args.head).match(/^issue-(\d+)/);
-        if (headMatch) {
-          const entry = ensureEntry(headMatch[1]);
-          // We don't know the PR number from the tool call args alone,
-          // but we know a PR was attempted. Mark with -1 as "attempted".
-          if (entry.pr === null) entry.pr = -1;
+        if (call.name === 'create_branch' && args.branch_name) {
+          const branchMatch = String(args.branch_name).match(/^issue-(\d+)/);
+          if (branchMatch) {
+            pendingBranchIssue = branchMatch[1];
+            pendingBranchName = String(args.branch_name);
+            ensureEntry(pendingBranchIssue);
+          }
+        }
+
+        if (call.name === 'create_or_update_file' && args.branch) {
+          const branchMatch = String(args.branch).match(/^issue-(\d+)/);
+          if (branchMatch) {
+            pendingCommitIssue = branchMatch[1];
+            ensureEntry(pendingCommitIssue);
+          }
+        }
+
+        if (call.name === 'create_pull_request' && args.head) {
+          const headMatch = String(args.head).match(/^issue-(\d+)/);
+          if (headMatch) {
+            pendingPrIssue = headMatch[1];
+            ensureEntry(pendingPrIssue);
+          }
         }
       }
     }
 
-    // Check tool responses for PR numbers
     if (typeof msg.content === 'string') {
       try {
         const parsed = JSON.parse(msg.content);
+
+        if (pendingCommentIssue && parsed.id && parsed.html_url && typeof parsed.body === 'string') {
+          ensureEntry(pendingCommentIssue).comment = { id: parsed.id, html_url: parsed.html_url };
+          pendingCommentIssue = null;
+        }
+
+        if (pendingBranchIssue && pendingBranchName && parsed.ref && parsed.object?.sha) {
+          ensureEntry(pendingBranchIssue).branch = { name: pendingBranchName, sha: parsed.object.sha };
+          pendingBranchIssue = null;
+          pendingBranchName = null;
+        }
+
+        if (pendingCommitIssue && parsed.content?.sha && parsed.commit?.sha) {
+          ensureEntry(pendingCommitIssue).commits.push({
+            path: parsed.content.path ?? '',
+            sha: parsed.content.sha,
+            commit_sha: parsed.commit.sha,
+          });
+          pendingCommitIssue = null;
+        }
+
         if (parsed.number && parsed.html_url && parsed.draft !== undefined) {
-          // This looks like a PR response. Try to find the issue from the title.
           const titleMatch = String(parsed.title ?? '').match(/Fix #(\d+)/);
-          const urlMatch = String(parsed.html_url ?? '').match(/\/pull\/(\d+)/);
-          if (titleMatch && urlMatch) {
-            const entry = ensureEntry(titleMatch[1]);
-            entry.pr = parsed.number;
+          if (titleMatch) {
+            ensureEntry(titleMatch[1]).pr = { number: parsed.number, html_url: parsed.html_url };
+            pendingPrIssue = null;
+          } else if (pendingPrIssue) {
+            ensureEntry(pendingPrIssue).pr = { number: parsed.number, html_url: parsed.html_url };
+            pendingPrIssue = null;
+          }
+        }
+
+        if (parsed.skipped) {
+          if (pendingCommentIssue && parsed.existing_comment_url) {
+            ensureEntry(pendingCommentIssue).comment = { id: parsed.comment_id ?? 0, html_url: parsed.existing_comment_url };
+            pendingCommentIssue = null;
+          }
+          if (pendingBranchIssue && pendingBranchName && parsed.branch_url) {
+            ensureEntry(pendingBranchIssue).branch = { name: pendingBranchName, sha: '' };
+            pendingBranchIssue = null;
+            pendingBranchName = null;
+          }
+          if (pendingPrIssue && parsed.existing_pr_url) {
+            ensureEntry(pendingPrIssue).pr = { number: parsed.pr_number ?? 0, html_url: parsed.existing_pr_url };
+            pendingPrIssue = null;
           }
         }
       } catch {
@@ -193,13 +279,13 @@ export function buildUserMessage(
   let actionContext = '';
   if (issueActions && Object.keys(issueActions).length > 0) {
     const incomplete = Object.entries(issueActions)
-      .filter(([, actions]) => !actions.commented || !actions.branch || actions.pr === null)
-      .map(([num, actions]) => {
+      .filter(([, a]) => !a.comment || !a.branch || a.pr === null)
+      .map(([num, a]) => {
         const done: string[] = [];
         const todo: string[] = [];
-        if (actions.commented) done.push('commented'); else todo.push('comment');
-        if (actions.branch) done.push(`branch: ${actions.branch}`); else todo.push('create branch');
-        if (actions.pr !== null && actions.pr > 0) done.push(`PR #${actions.pr}`); else todo.push('open PR');
+        if (a.comment) done.push('commented'); else todo.push('comment');
+        if (a.branch) done.push(`branch: ${a.branch.name}`); else todo.push('create branch');
+        if (a.pr) done.push(`PR #${a.pr.number}`); else todo.push('open PR');
         return `  Issue #${num}: done=[${done.join(', ')}] remaining=[${todo.join(', ')}]`;
       });
 
@@ -588,11 +674,12 @@ export function showStatus(config: Config): void {
   // Show per-issue action tracking
   if (pollState.issues && Object.keys(pollState.issues).length > 0) {
     console.log('\nPer-issue actions:');
-    for (const [num, actions] of Object.entries(pollState.issues)) {
+    for (const [num, a] of Object.entries(pollState.issues)) {
       const status: string[] = [];
-      status.push(actions.commented ? 'commented' : 'no comment');
-      status.push(actions.branch ? `branch: ${actions.branch}` : 'no branch');
-      status.push(actions.pr !== null ? `PR #${actions.pr}` : 'no PR');
+      status.push(a.comment ? 'commented' : 'no comment');
+      status.push(a.branch ? `branch: ${a.branch.name}` : 'no branch');
+      if (a.commits.length > 0) status.push(`${a.commits.length} commit(s)`);
+      status.push(a.pr ? `PR #${a.pr.number}` : 'no PR');
       console.log(`  #${num}: ${status.join(', ')}`);
     }
   }

--- a/tests/core.test.ts
+++ b/tests/core.test.ts
@@ -210,13 +210,13 @@ describe('loadPollState', () => {
     };
     vi.mocked(fs.existsSync).mockReturnValue(true);
     vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify(state));
-    // migratePollState adds issues field to old-format state
+    // migratePollState adds issues field to old-format state (enriched format)
     expect(loadPollState()).toEqual({
       ...state,
       issues: {
-        '1': { commented: true, branch: null, pr: null },
-        '2': { commented: true, branch: null, pr: null },
-        '3': { commented: true, branch: null, pr: null },
+        '1': { comment: { id: 0, html_url: '' }, branch: null, commits: [], pr: null },
+        '2': { comment: { id: 0, html_url: '' }, branch: null, commits: [], pr: null },
+        '3': { comment: { id: 0, html_url: '' }, branch: null, commits: [], pr: null },
       },
     });
   });
@@ -246,31 +246,52 @@ describe('savePollState', () => {
 // ── migratePollState ────────────────────────────────────────────────────────
 
 describe('migratePollState', () => {
-  it('passes through new-format state unchanged', () => {
+  it('passes through enriched-format state unchanged', () => {
     const state = {
       lastPollTimestamp: '2026-01-01T00:00:00Z',
       lastPollIssueNumbers: [1, 2],
       issues: {
-        '1': { commented: true, branch: 'issue-1-fix', pr: 5 },
-        '2': { commented: true, branch: null, pr: null },
+        '1': { comment: { id: 100, html_url: 'https://x' }, branch: { name: 'issue-1-fix', sha: 'abc' }, commits: [], pr: { number: 5, html_url: 'https://y' } },
+        '2': { comment: null, branch: null, commits: [], pr: null },
       },
     };
     expect(migratePollState(state)).toEqual(state);
   });
 
-  it('migrates old-format state to new format with stub actions', () => {
+  it('migrates pre-v0.2.10 state (no issues field) to enriched format', () => {
     const old = {
       lastPollTimestamp: '2026-01-01T00:00:00Z',
       lastPollIssueNumbers: [3, 7],
     };
     const result = migratePollState(old);
     expect(result.issues).toBeDefined();
-    expect(result.issues!['3']).toEqual({ commented: true, branch: null, pr: null });
-    expect(result.issues!['7']).toEqual({ commented: true, branch: null, pr: null });
+    expect(result.issues!['3']).toEqual({ comment: { id: 0, html_url: '' }, branch: null, commits: [], pr: null });
+    expect(result.issues!['7']).toEqual({ comment: { id: 0, html_url: '' }, branch: null, commits: [], pr: null });
     expect(result.lastPollIssueNumbers).toEqual([3, 7]);
   });
 
-  it('handles old state with empty issue list', () => {
+  it('migrates v0.2.10 boolean format to enriched format', () => {
+    const old = {
+      lastPollTimestamp: '2026-01-01T00:00:00Z',
+      lastPollIssueNumbers: [1, 2],
+      issues: {
+        '1': { commented: true, branch: 'issue-1-fix', pr: 5 },
+        '2': { commented: false, branch: null, pr: null },
+      },
+    };
+    const result = migratePollState(old);
+    expect(result.issues!['1']).toEqual({
+      comment: { id: 0, html_url: '' },
+      branch: { name: 'issue-1-fix', sha: '' },
+      commits: [],
+      pr: { number: 5, html_url: '' },
+    });
+    expect(result.issues!['2']).toEqual({
+      comment: null, branch: null, commits: [], pr: null,
+    });
+  });
+
+  it('handles pre-v0.2.10 state with empty issue list', () => {
     const old = {
       lastPollTimestamp: '2026-01-01T00:00:00Z',
       lastPollIssueNumbers: [],
@@ -278,51 +299,67 @@ describe('migratePollState', () => {
     const result = migratePollState(old);
     expect(result.issues).toEqual({});
   });
+
+  it('migrates v0.2.10 pr=-1 (attempted) as null in enriched format', () => {
+    const old = {
+      lastPollTimestamp: '2026-01-01T00:00:00Z',
+      lastPollIssueNumbers: [4],
+      issues: {
+        '4': { commented: true, branch: null, pr: -1 },
+      },
+    };
+    const result = migratePollState(old);
+    expect(result.issues!['4'].pr).toBeNull();
+  });
 });
 
 // ── extractIssueActions ─────────────────────────────────────────────────────
 
 describe('extractIssueActions', () => {
   it('returns existing actions when messages are empty', () => {
-    const existing = { '1': { commented: true, branch: 'b', pr: 5 } };
+    const existing = { '1': { comment: { id: 10, html_url: 'u' }, branch: null, commits: [], pr: null } };
     const result = extractIssueActions([], existing);
     expect(result).toEqual(existing);
   });
 
-  it('tracks comment_on_issue calls', () => {
+  it('creates empty entry for comment_on_issue call', () => {
     const messages = [
       { tool_calls: [{ name: 'comment_on_issue', args: { issue_number: 3, body: 'analysis' } }] },
     ];
     const result = extractIssueActions(messages);
-    expect(result['3'].commented).toBe(true);
+    // Entry created but no response yet, so comment is still null
+    expect(result['3']).toBeDefined();
+    expect(result['3'].comment).toBeNull();
   });
 
-  it('tracks create_branch calls and extracts issue number from branch name', () => {
+  it('creates empty entry for create_branch call', () => {
     const messages = [
       { tool_calls: [{ name: 'create_branch', args: { branch_name: 'issue-5-fix-login' } }] },
     ];
     const result = extractIssueActions(messages);
-    expect(result['5'].branch).toBe('issue-5-fix-login');
+    expect(result['5']).toBeDefined();
+    expect(result['5'].branch).toBeNull();
   });
 
-  it('tracks create_pull_request calls', () => {
+  it('creates empty entry for create_pull_request call', () => {
     const messages = [
       { tool_calls: [{ name: 'create_pull_request', args: { title: 'Fix #8', head: 'issue-8-fix', body: 'Closes #8' } }] },
     ];
     const result = extractIssueActions(messages);
-    expect(result['8'].pr).toBe(-1); // -1 = attempted (PR number not known from call args)
+    expect(result['8']).toBeDefined();
+    expect(result['8'].pr).toBeNull();
   });
 
-  it('merges new actions with existing actions', () => {
+  it('preserves existing when merging new tool call entries', () => {
     const existing: Record<string, IssueActions> = {
-      '1': { commented: true, branch: null, pr: null },
+      '1': { comment: { id: 10, html_url: 'u' }, branch: null, commits: [], pr: null },
     };
     const messages = [
       { tool_calls: [{ name: 'create_branch', args: { branch_name: 'issue-1-fix' } }] },
     ];
     const result = extractIssueActions(messages, existing);
-    expect(result['1'].commented).toBe(true); // preserved from existing
-    expect(result['1'].branch).toBe('issue-1-fix'); // added from new message
+    expect(result['1'].comment).toEqual({ id: 10, html_url: 'u' }); // preserved
+    expect(result['1'].branch).toBeNull(); // pending, no response yet
   });
 
   it('ignores branch names that do not match issue-N pattern', () => {
@@ -334,12 +371,124 @@ describe('extractIssueActions', () => {
   });
 });
 
+// ── enriched metadata capture ────────────────────────────────────────────────
+
+describe('enriched metadata', () => {
+  it('captures comment metadata from response', () => {
+    const messages = [
+      { tool_calls: [{ name: 'comment_on_issue', args: { issue_number: 3, body: 'hi' } }] },
+      { content: JSON.stringify({ id: 100, html_url: 'https://github.com/x/y/issues/3#issuecomment-100', body: 'hi' }) },
+    ];
+    const result = extractIssueActions(messages);
+    expect(result['3'].comment).toEqual({ id: 100, html_url: 'https://github.com/x/y/issues/3#issuecomment-100' });
+  });
+
+  it('captures branch metadata from response', () => {
+    const messages = [
+      { tool_calls: [{ name: 'create_branch', args: { branch_name: 'issue-5-fix' } }] },
+      { content: JSON.stringify({ ref: 'refs/heads/issue-5-fix', object: { sha: 'abc123' } }) },
+    ];
+    const result = extractIssueActions(messages);
+    expect(result['5'].branch).toEqual({ name: 'issue-5-fix', sha: 'abc123' });
+  });
+
+  it('captures commit metadata from response', () => {
+    const messages = [
+      { tool_calls: [{ name: 'create_or_update_file', args: { branch: 'issue-7-fix', path: 'src/foo.ts', content: 'x' } }] },
+      { content: JSON.stringify({ content: { path: 'src/foo.ts', sha: 'file-sha' }, commit: { sha: 'commit-sha' } }) },
+    ];
+    const result = extractIssueActions(messages);
+    expect(result['7'].commits).toEqual([{ path: 'src/foo.ts', sha: 'file-sha', commit_sha: 'commit-sha' }]);
+  });
+
+  it('captures PR metadata via title match', () => {
+    const messages = [
+      { tool_calls: [{ name: 'create_pull_request', args: { title: 'Fix #8: bug', head: 'issue-8-fix' } }] },
+      { content: JSON.stringify({ number: 42, html_url: 'https://github.com/x/y/pull/42', title: 'Fix #8: bug', draft: true }) },
+    ];
+    const result = extractIssueActions(messages);
+    expect(result['8'].pr).toEqual({ number: 42, html_url: 'https://github.com/x/y/pull/42' });
+  });
+
+  it('captures PR metadata via pending state when title does not match', () => {
+    const messages = [
+      { tool_calls: [{ name: 'create_pull_request', args: { title: 'Some PR', head: 'issue-9-fix' } }] },
+      { content: JSON.stringify({ number: 55, html_url: 'https://github.com/x/y/pull/55', title: 'Some PR', draft: true }) },
+    ];
+    const result = extractIssueActions(messages);
+    expect(result['9'].pr).toEqual({ number: 55, html_url: 'https://github.com/x/y/pull/55' });
+  });
+
+  it('captures full workflow: comment + branch + commit + PR', () => {
+    const messages = [
+      { tool_calls: [{ name: 'comment_on_issue', args: { issue_number: 10, body: 'analysis' } }] },
+      { content: JSON.stringify({ id: 200, html_url: 'https://c', body: 'analysis' }) },
+      { tool_calls: [{ name: 'create_branch', args: { branch_name: 'issue-10-fix' } }] },
+      { content: JSON.stringify({ ref: 'refs/heads/issue-10-fix', object: { sha: 'bbb' } }) },
+      { tool_calls: [{ name: 'create_or_update_file', args: { branch: 'issue-10-fix', path: 'f.ts', content: 'x' } }] },
+      { content: JSON.stringify({ content: { path: 'f.ts', sha: 'fs' }, commit: { sha: 'cs' } }) },
+      { tool_calls: [{ name: 'create_pull_request', args: { title: 'Fix #10: x', head: 'issue-10-fix' } }] },
+      { content: JSON.stringify({ number: 77, html_url: 'https://pr', title: 'Fix #10: x', draft: true }) },
+    ];
+    const result = extractIssueActions(messages);
+    expect(result['10'].comment).toEqual({ id: 200, html_url: 'https://c' });
+    expect(result['10'].branch).toEqual({ name: 'issue-10-fix', sha: 'bbb' });
+    expect(result['10'].commits).toEqual([{ path: 'f.ts', sha: 'fs', commit_sha: 'cs' }]);
+    expect(result['10'].pr).toEqual({ number: 77, html_url: 'https://pr' });
+  });
+
+  it('handles skipped comment response', () => {
+    const messages = [
+      { tool_calls: [{ name: 'comment_on_issue', args: { issue_number: 1 } }] },
+      { content: JSON.stringify({ skipped: true, comment_id: 50, existing_comment_url: 'https://skip-c' }) },
+    ];
+    const result = extractIssueActions(messages);
+    expect(result['1'].comment).toEqual({ id: 50, html_url: 'https://skip-c' });
+  });
+
+  it('handles skipped branch response', () => {
+    const messages = [
+      { tool_calls: [{ name: 'create_branch', args: { branch_name: 'issue-2-fix' } }] },
+      { content: JSON.stringify({ skipped: true, branch_url: 'https://skip-b' }) },
+    ];
+    const result = extractIssueActions(messages);
+    expect(result['2'].branch).toEqual({ name: 'issue-2-fix', sha: '' });
+  });
+
+  it('handles skipped PR response', () => {
+    const messages = [
+      { tool_calls: [{ name: 'create_pull_request', args: { head: 'issue-4-fix' } }] },
+      { content: JSON.stringify({ skipped: true, pr_number: 99, existing_pr_url: 'https://skip-pr' }) },
+    ];
+    const result = extractIssueActions(messages);
+    expect(result['4'].pr).toEqual({ number: 99, html_url: 'https://skip-pr' });
+  });
+
+  it('handles non-JSON content gracefully', () => {
+    const messages = [
+      { tool_calls: [{ name: 'comment_on_issue', args: { issue_number: 6 } }] },
+      { content: 'This is not JSON' },
+    ];
+    const result = extractIssueActions(messages);
+    expect(result['6']).toBeDefined();
+    expect(result['6'].comment).toBeNull();
+  });
+
+  it('creates empty entry with correct shape', () => {
+    const messages = [
+      { tool_calls: [{ name: 'comment_on_issue', args: { issue_number: 99 } }] },
+    ];
+    const result = extractIssueActions(messages);
+    expect(result['99']).toEqual({ comment: null, branch: null, commits: [], pr: null });
+  });
+});
+
 // ── buildUserMessage with action context ────────────────────────────────────
 
 describe('buildUserMessage with issueActions', () => {
   it('includes partial action status in the message', () => {
     const actions: Record<string, IssueActions> = {
-      '5': { commented: true, branch: null, pr: null },
+      '5': { comment: { id: 1, html_url: 'u' }, branch: null, commits: [], pr: null },
     };
     const msg = buildUserMessage(5, '2026-01-01T00:00:00Z', [5], actions);
     expect(msg).toContain('Issue #5');
@@ -350,7 +499,7 @@ describe('buildUserMessage with issueActions', () => {
 
   it('does not include fully-processed issues in partial list', () => {
     const actions: Record<string, IssueActions> = {
-      '3': { commented: true, branch: 'issue-3-fix', pr: 10 },
+      '3': { comment: { id: 1, html_url: 'u' }, branch: { name: 'issue-3-fix', sha: 's' }, commits: [], pr: { number: 10, html_url: 'p' } },
     };
     const msg = buildUserMessage(5, '2026-01-01T00:00:00Z', [3], actions);
     expect(msg).not.toContain('Partially-processed');


### PR DESCRIPTION
## Summary

- `IssueActions` now stores full API response metadata (comment IDs, branch SHAs, file SHAs, PR numbers/URLs) instead of simple booleans/strings
- `extractIssueActions()` correlates tool calls with responses using pending-state tracking
- `migratePollState()` handles 3 format generations (pre-v0.2.10, v0.2.10 boolean, v0.3.4+ enriched)
- `buildUserMessage()` and `showStatus()` updated for enriched field names
- 12 new tests covering metadata capture, skipped responses, full workflow — all 126 tests passing

## Changed files

- `src/core.ts` — IssueActions interface, extractIssueActions, migratePollState, buildUserMessage, showStatus
- `tests/core.test.ts` — updated existing tests + new `describe('enriched metadata', ...)` block
- `package.json` — version bump to v0.3.4
- `CHANGELOG.md` — v0.3.4 entry
- `LEARNING_LOG.md` — Entry 28: state schema evolution

## Version bump rationale

v0.3.4 (patch): Breaking change to `IssueActions` interface shape, but fully backwards-compatible via migration. No external consumers — internal data structure only.

Closes #31