### PR TITLE
Handle pull_request.opened webhook event (Issue #14)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@
 
 ---
 
+## v0.5.2 — 2026-02-08
+
+### Added
+- **Handle `pull_request.opened` webhook event** (Issue #14) — dispatches PR events from the webhook listener
+- `handlePullRequestEvent()` extracts PR metadata (number, title, body, head/base ref, draft status)
+- **Loop prevention**: `isBotPr()` checks for `<!-- deep-agent-pr -->` HTML marker in PR body OR `issue-N-*` branch naming pattern
+- Bot-created PRs are logged as "queued for review" (stub — actual reviewer bot deferred to Issue #15)
+- Non-bot PRs are ignored (logged and skipped)
+- `handleWebhookEvent()` dispatcher routes events to the correct handler
+- Fire-and-forget pattern: webhook responds 200 immediately, dispatches handler after response
+- `PrReviewStub` interface exported for Issue #15 to wire into
+- `PrHandlerResult` and `PrOpenedData` interfaces for typed handler results
+- 17 new tests: isBotPr (5), handlePullRequestEvent (9), handleWebhookEvent dispatcher (3)
+
+---
+
 ## v0.5.0 — 2026-02-08
 
 **Milestone: Phase 5 (Resilience) complete.** Transient API failures are retried. Container stops don't lose work. Agent actions can be retracted by humans via CLI. Tool calls are logged with arguments and timing.

--- a/LEARNING_LOG.md
+++ b/LEARNING_LOG.md
@@ -5278,3 +5278,42 @@ This is the exact same pattern as Batch 1's CHANGELOG/LEARNING_LOG conflicts, bu
 **Merge order: PR #41 first, then rebase and merge PR #40.**
 
 **Test counts after both merge:** 198 total (191 from PR #41 + 7 new retract tests from PR #40). Both branches pass all tests independently.
+
+---
+
+## Entry 41: PR.opened Webhook Handler -- Loop Prevention and Stub Design (Issue #14)
+
+**Date:** 2026-02-08
+**Author:** Builder Agent
+**Issue:** #14 — Handle `pull_request.opened` webhook event
+
+### What we built
+
+A handler for `pull_request.opened` events in the webhook listener. When GitHub sends a PR event, the handler decides whether it was created by our bot and logs it for future review.
+
+### Key design decision: Loop prevention
+
+The bot creates PRs as part of its workflow (via `create_pull_request` tool). If the webhook listener naively processed every PR event, it could trigger an infinite loop: bot creates PR -> webhook fires -> bot processes PR -> bot creates another PR -> ...
+
+We prevent this with a **dual-signal check** in `isBotPr()`:
+
+1. **HTML marker** (`<!-- deep-agent-pr -->`) — the `create_pull_request` tool already embeds this in PR bodies. This is the primary signal.
+2. **Branch naming convention** (`issue-N-*` regex) — a fallback signal if the marker is missing or the PR body was edited.
+
+If *either* signal matches, we treat it as a bot-created PR. This is deliberately permissive — false positives (treating a human PR as bot-created) are harmless (we just log it), while false negatives (treating a bot PR as human) could cause loops.
+
+### Why a stub, not the full reviewer
+
+Issue #15 will implement the actual PR review agent. This handler is a hook point: it extracts metadata, checks for bot origin, and returns a `PrHandlerResult` with `reviewQueued: true`. The `PrReviewStub` interface is exported so #15 can wire in without modifying the handler's dispatch logic.
+
+### Fire-and-forget pattern
+
+The webhook endpoint responds 200 immediately, then dispatches to handlers. This follows GitHub's guidance: webhook deliveries time out after 10 seconds, so long-running work should be deferred. The handler is synchronous today (just logging), but the pattern is ready for async work in #15.
+
+### The dispatcher
+
+`handleWebhookEvent()` is a simple router that checks `event.event` and delegates. It returns `null` for unhandled events, making it easy for #13 (issues.opened) to add its case. Both #13 and #14 can merge independently — the dispatcher handles the union.
+
+### Test coverage
+
+17 new tests covering: `isBotPr` helper (5), `handlePullRequestEvent` (9 cases including bot/non-bot/missing-data/wrong-action), `handleWebhookEvent` dispatcher (3). Total: 215 tests across 8 files.

--- a/src/listener.ts
+++ b/src/listener.ts
@@ -1,6 +1,6 @@
 import { createHmac, timingSafeEqual } from 'crypto';
 import express from 'express';
-import type { Request, Response, NextFunction } from 'express';
+import type { Request, Response } from 'express';
 
 /**
  * Webhook listener configuration.
@@ -20,6 +20,121 @@ export interface WebhookEvent {
   deliveryId: string;
   /** The parsed JSON payload */
   payload: Record<string, unknown>;
+}
+
+/** Marker that identifies PRs created by this bot. */
+export const BOT_PR_MARKER = '<!-- deep-agent-pr -->';
+
+/** Branch naming pattern used by the bot: issue-N-description */
+const BOT_BRANCH_RE = /^issue-\d+-/;
+
+/**
+ * Extracted metadata from a pull_request.opened payload.
+ */
+export interface PrOpenedData {
+  number: number;
+  title: string;
+  body: string;
+  headRef: string;
+  baseRef: string;
+  draft: boolean;
+}
+
+/**
+ * Result of handling a pull_request.opened event.
+ * The `reviewQueued` field indicates whether the PR was recognized as
+ * bot-created and queued for future review (Issue #15).
+ */
+export interface PrHandlerResult {
+  handled: boolean;
+  reviewQueued: boolean;
+  reason: string;
+  pr?: PrOpenedData;
+}
+
+/**
+ * Stub interface for the future PR reviewer (Issue #15).
+ * When the reviewer bot is implemented, it will satisfy this interface
+ * and be wired into handlePullRequestEvent.
+ */
+export interface PrReviewStub {
+  reviewPr(pr: PrOpenedData): Promise<void>;
+}
+
+/**
+ * Check if a PR was created by this bot.
+ * Uses two signals: the HTML marker in the PR body, or the branch naming convention.
+ */
+export function isBotPr(body: string, headRef: string): boolean {
+  return body.includes(BOT_PR_MARKER) || BOT_BRANCH_RE.test(headRef);
+}
+
+/**
+ * Handle a pull_request.opened webhook event.
+ *
+ * - If the PR was created by the bot, log it as queued for review and return.
+ *   (The actual reviewer bot will be added in Issue #15.)
+ * - If the PR was NOT created by the bot, ignore it.
+ * - Returns immediately (fire-and-forget pattern for the webhook endpoint).
+ */
+export function handlePullRequestEvent(event: WebhookEvent): PrHandlerResult {
+  const { payload } = event;
+
+  if (payload.action !== 'opened') {
+    return { handled: false, reviewQueued: false, reason: `Ignored action: ${payload.action}` };
+  }
+
+  const pr = payload.pull_request as Record<string, unknown> | undefined;
+  if (!pr || typeof pr.number !== 'number') {
+    console.error(`[webhook] pull_request.opened missing PR data (delivery: ${event.deliveryId})`);
+    return { handled: false, reviewQueued: false, reason: 'Missing PR data in payload' };
+  }
+
+  const head = pr.head as Record<string, unknown> | undefined;
+  const base = pr.base as Record<string, unknown> | undefined;
+
+  const prData: PrOpenedData = {
+    number: pr.number as number,
+    title: (pr.title as string) ?? '',
+    body: (pr.body as string) ?? '',
+    headRef: (head?.ref as string) ?? '',
+    baseRef: (base?.ref as string) ?? '',
+    draft: (pr.draft as boolean) ?? false,
+  };
+
+  if (!isBotPr(prData.body, prData.headRef)) {
+    console.log(
+      `[webhook] PR #${prData.number} not created by bot, ignoring ` +
+      `(delivery: ${event.deliveryId})`,
+    );
+    return { handled: true, reviewQueued: false, reason: 'PR not created by bot', pr: prData };
+  }
+
+  // Bot-created PR — queue for review (stub until Issue #15)
+  console.log(
+    `[webhook] PR #${prData.number} "${prData.title}" queued for review ` +
+    `(delivery: ${event.deliveryId}) [reviewer not implemented yet]`,
+  );
+
+  return {
+    handled: true,
+    reviewQueued: true,
+    reason: 'Queued for review (reviewer not implemented yet — see Issue #15)',
+    pr: prData,
+  };
+}
+
+/**
+ * Dispatch a parsed webhook event to the appropriate handler.
+ * Returns the handler result, or null if no handler matched.
+ */
+export function handleWebhookEvent(event: WebhookEvent): PrHandlerResult | null {
+  if (event.event === 'pull_request') {
+    return handlePullRequestEvent(event);
+  }
+
+  // Other event types will be added here (e.g. issues.opened from #13)
+  return null;
 }
 
 /**
@@ -112,14 +227,22 @@ export function createWebhookApp(config: WebhookConfig): express.Express {
       payload,
     };
 
-    // Log the event (actual handling deferred to #13/#14)
+    // Log the event
     const action = typeof payload.action === 'string' ? payload.action : '';
     console.log(
       `[webhook] Received: ${event}${action ? `.${action}` : ''} ` +
       `(delivery: ${webhookEvent.deliveryId})`,
     );
 
+    // Fire-and-forget: respond 200 immediately, then dispatch
     res.status(200).json({ received: true, event, deliveryId: webhookEvent.deliveryId });
+
+    // Dispatch to event handlers (async, after response is sent)
+    try {
+      handleWebhookEvent(webhookEvent);
+    } catch (err) {
+      console.error(`[webhook] Handler error for ${event}.${action}:`, err);
+    }
   });
 
   return app;

--- a/tests/listener.test.ts
+++ b/tests/listener.test.ts
@@ -1,7 +1,14 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { createHmac } from 'crypto';
-import { createWebhookApp, verifySignature } from '../src/listener.js';
-import type { WebhookConfig } from '../src/listener.js';
+import {
+  createWebhookApp,
+  verifySignature,
+  handlePullRequestEvent,
+  handleWebhookEvent,
+  isBotPr,
+  BOT_PR_MARKER,
+} from '../src/listener.js';
+import type { WebhookConfig, WebhookEvent } from '../src/listener.js';
 
 // ── verifySignature ──────────────────────────────────────────────────────────
 
@@ -260,5 +267,234 @@ describe('createWebhookApp', () => {
 
     expect(res.status).toBe(400);
     expect(res.body.error).toBe('Invalid JSON payload');
+  });
+});
+
+// ── isBotPr ─────────────────────────────────────────────────────────────────
+
+describe('isBotPr', () => {
+  it('returns true when body contains the bot marker', () => {
+    expect(isBotPr(`Some text ${BOT_PR_MARKER} more text`, 'feature-branch')).toBe(true);
+  });
+
+  it('returns true when branch matches issue-N-* pattern', () => {
+    expect(isBotPr('no marker here', 'issue-42-fix-login')).toBe(true);
+  });
+
+  it('returns true when both marker and branch match', () => {
+    expect(isBotPr(`Body with ${BOT_PR_MARKER}`, 'issue-7-update')).toBe(true);
+  });
+
+  it('returns false for non-bot PR', () => {
+    expect(isBotPr('Regular PR body', 'feature/my-change')).toBe(false);
+  });
+
+  it('returns false for branch that looks similar but does not match', () => {
+    expect(isBotPr('', 'issues-42-wrong-prefix')).toBe(false);
+  });
+});
+
+// ── handlePullRequestEvent ──────────────────────────────────────────────────
+
+describe('handlePullRequestEvent', () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function makeEvent(overrides: Partial<WebhookEvent> & { payload: Record<string, unknown> }): WebhookEvent {
+    return {
+      event: 'pull_request',
+      deliveryId: 'test-delivery',
+      ...overrides,
+    };
+  }
+
+  function makePrPayload(opts: {
+    action?: string;
+    number?: number;
+    title?: string;
+    body?: string;
+    headRef?: string;
+    baseRef?: string;
+    draft?: boolean;
+  } = {}): Record<string, unknown> {
+    return {
+      action: opts.action ?? 'opened',
+      pull_request: {
+        number: opts.number ?? 99,
+        title: opts.title ?? 'Fix #42: test fix',
+        body: opts.body ?? `Some description\n${BOT_PR_MARKER}\nCloses #42`,
+        draft: opts.draft ?? true,
+        head: { ref: opts.headRef ?? 'issue-42-test-fix' },
+        base: { ref: opts.baseRef ?? 'main' },
+      },
+    };
+  }
+
+  it('queues bot-created PR (marker in body) for review', () => {
+    const event = makeEvent({ payload: makePrPayload({ body: `text ${BOT_PR_MARKER} text` }) });
+    const result = handlePullRequestEvent(event);
+
+    expect(result.handled).toBe(true);
+    expect(result.reviewQueued).toBe(true);
+    expect(result.reason).toContain('Issue #15');
+    expect(result.pr?.number).toBe(99);
+  });
+
+  it('queues bot-created PR (branch pattern) for review', () => {
+    const event = makeEvent({
+      payload: makePrPayload({ body: 'no marker', headRef: 'issue-10-add-tests' }),
+    });
+    const result = handlePullRequestEvent(event);
+
+    expect(result.handled).toBe(true);
+    expect(result.reviewQueued).toBe(true);
+  });
+
+  it('ignores non-bot PR', () => {
+    const event = makeEvent({
+      payload: makePrPayload({
+        body: 'Regular PR from a human',
+        headRef: 'feature/my-change',
+      }),
+    });
+    const result = handlePullRequestEvent(event);
+
+    expect(result.handled).toBe(true);
+    expect(result.reviewQueued).toBe(false);
+    expect(result.reason).toBe('PR not created by bot');
+    expect(result.pr?.number).toBe(99);
+  });
+
+  it('ignores pull_request.closed action', () => {
+    const event = makeEvent({ payload: makePrPayload({ action: 'closed' }) });
+    const result = handlePullRequestEvent(event);
+
+    expect(result.handled).toBe(false);
+    expect(result.reviewQueued).toBe(false);
+    expect(result.reason).toContain('Ignored action: closed');
+  });
+
+  it('ignores pull_request.synchronize action', () => {
+    const event = makeEvent({ payload: makePrPayload({ action: 'synchronize' }) });
+    const result = handlePullRequestEvent(event);
+
+    expect(result.handled).toBe(false);
+    expect(result.reason).toContain('Ignored action: synchronize');
+  });
+
+  it('handles missing pull_request in payload gracefully', () => {
+    const event = makeEvent({ payload: { action: 'opened' } });
+    const result = handlePullRequestEvent(event);
+
+    expect(result.handled).toBe(false);
+    expect(result.reason).toBe('Missing PR data in payload');
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining('missing PR data'),
+    );
+  });
+
+  it('handles pull_request with missing number gracefully', () => {
+    const event = makeEvent({
+      payload: {
+        action: 'opened',
+        pull_request: { title: 'No number field' },
+      },
+    });
+    const result = handlePullRequestEvent(event);
+
+    expect(result.handled).toBe(false);
+    expect(result.reason).toBe('Missing PR data in payload');
+  });
+
+  it('extracts PR metadata correctly', () => {
+    const event = makeEvent({
+      payload: makePrPayload({
+        number: 55,
+        title: 'Fix #10: handle edge case',
+        body: `Detailed description\n${BOT_PR_MARKER}`,
+        headRef: 'issue-10-edge-case',
+        baseRef: 'develop',
+        draft: false,
+      }),
+    });
+    const result = handlePullRequestEvent(event);
+
+    expect(result.pr).toEqual({
+      number: 55,
+      title: 'Fix #10: handle edge case',
+      body: `Detailed description\n${BOT_PR_MARKER}`,
+      headRef: 'issue-10-edge-case',
+      baseRef: 'develop',
+      draft: false,
+    });
+  });
+
+  it('returns reviewQueued: true with clear "not implemented" indicator', () => {
+    const event = makeEvent({ payload: makePrPayload() });
+    const result = handlePullRequestEvent(event);
+
+    expect(result.reviewQueued).toBe(true);
+    expect(result.reason).toMatch(/not implemented/i);
+  });
+});
+
+// ── handleWebhookEvent (dispatcher) ─────────────────────────────────────────
+
+describe('handleWebhookEvent', () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('dispatches pull_request events to handlePullRequestEvent', () => {
+    const event: WebhookEvent = {
+      event: 'pull_request',
+      deliveryId: 'dispatch-1',
+      payload: {
+        action: 'opened',
+        pull_request: {
+          number: 77,
+          title: 'Test',
+          body: BOT_PR_MARKER,
+          draft: true,
+          head: { ref: 'issue-77-test' },
+          base: { ref: 'main' },
+        },
+      },
+    };
+
+    const result = handleWebhookEvent(event);
+    expect(result).not.toBeNull();
+    expect(result!.reviewQueued).toBe(true);
+  });
+
+  it('returns null for unhandled event types', () => {
+    const event: WebhookEvent = {
+      event: 'push',
+      deliveryId: 'dispatch-2',
+      payload: { ref: 'refs/heads/main' },
+    };
+
+    expect(handleWebhookEvent(event)).toBeNull();
+  });
+
+  it('returns null for issues event (not yet handled)', () => {
+    const event: WebhookEvent = {
+      event: 'issues',
+      deliveryId: 'dispatch-3',
+      payload: { action: 'opened', issue: { number: 1 } },
+    };
+
+    expect(handleWebhookEvent(event)).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

Closes #14

- Add `pull_request.opened` event handler to the webhook listener with **loop prevention**
- `isBotPr()` checks for `<!-- deep-agent-pr -->` HTML marker in PR body OR `issue-N-*` branch naming pattern (dual-signal, deliberately permissive)
- Bot-created PRs are logged as "queued for review" (stub -- actual reviewer deferred to Issue #15)
- Non-bot PRs are ignored (logged and skipped)
- `handleWebhookEvent()` dispatcher routes events to the correct handler
- Fire-and-forget: webhook responds 200 immediately, dispatches handler after response
- `PrReviewStub` interface exported for Issue #15 to wire into
- 17 new tests (isBotPr: 5, handlePullRequestEvent: 9, dispatcher: 3), total 215 passing
- CHANGELOG v0.5.2, LEARNING_LOG Entry 41

## Files Changed

- `src/listener.ts` -- PR handler, isBotPr, dispatcher, interfaces
- `tests/listener.test.ts` -- 17 new tests
- `CHANGELOG.md` -- v0.5.2 entry
- `LEARNING_LOG.md` -- Entry 41

## Test plan

- [x] All 215 tests pass (`pnpm test`)
- [x] Bot-created PRs (marker in body) trigger review stub
- [x] Bot-created PRs (branch pattern) trigger review stub
- [x] Non-bot PRs are ignored
- [x] pull_request.closed/synchronize actions are ignored
- [x] Missing PR data handled gracefully
- [x] Stub returns clear "reviewer not implemented yet" indicator
- [x] No builder-13 cross-contamination in the diff