### PR TITLE
Fix #21: Docker + Caddy deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+node_modules/
+.git/
+config.json
+last_poll.json
+poll.log
+poll.lock/
+issues/
+tests/
+.claude/
+CLAUDE.md
+*.md
+!README.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@
 
 ---
 
+## v0.6.1 — 2026-02-09
+
+### Added
+- **Docker + Caddy deployment** (Issue #21) — containerized deployment with automatic HTTPS
+- `Dockerfile`: Node 24-slim base, pnpm via corepack, healthcheck against GET /health
+- `docker-compose.yml`: two-service stack (bot + Caddy reverse proxy) with health-gated startup
+- `Caddyfile`: reverse proxy with automatic TLS via Let's Encrypt (placeholder domain)
+- `.dockerignore`: excludes node_modules, .git, credentials, tests, and generated files
+- README "Docker Deployment" section with step-by-step setup instructions
+
+---
+
 ## v0.6.0 — 2026-02-09
 
 **Milestone: Phase 6 (Webhook & Real-Time) partially complete.** The webhook listener now dispatches `issues.opened` and `pull_request.opened` events. Issue #18 (persistent job queue) deferred — not needed for learning goals.

--- a/Caddyfile
+++ b/Caddyfile
@@ -1,0 +1,6 @@
+# Replace yourdomain.com with your actual domain.
+# Caddy automatically provisions TLS certificates via Let's Encrypt.
+
+yourdomain.com {
+	reverse_proxy bot:3000
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+# syntax=docker/dockerfile:1
+
+FROM node:24-slim AS base
+
+# Install pnpm via corepack (bundled with Node 24+)
+RUN corepack enable && corepack prepare pnpm@latest --activate
+
+WORKDIR /app
+
+# ── Install dependencies ────────────────────────────────────────────────────
+
+COPY package.json pnpm-lock.yaml ./
+RUN pnpm install --frozen-lockfile
+
+# ── Copy source ─────────────────────────────────────────────────────────────
+
+COPY src/ src/
+COPY tsconfig.json ./
+
+# ── Runtime ─────────────────────────────────────────────────────────────────
+
+EXPOSE 3000
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+  CMD node -e "fetch('http://localhost:3000/health').then(r=>{if(!r.ok)throw r.status}).catch(()=>process.exit(1))"
+
+CMD ["pnpm", "webhook"]

--- a/LEARNING_LOG.md
+++ b/LEARNING_LOG.md
@@ -5337,3 +5337,44 @@ The webhook endpoint responds 200 immediately, then dispatches to handlers. This
 ### Test coverage
 
 17 new tests covering: `isBotPr` helper (5), `handlePullRequestEvent` (9 cases including bot/non-bot/missing-data/wrong-action), `handleWebhookEvent` dispatcher (3). Total: 215 tests across 8 files.
+
+---
+
+## Entry 42: Docker + Caddy Deployment -- From Local Script to Containerized Service (Issue #21)
+
+**Date:** 2026-02-09
+**Author:** Builder Agent
+**Issue:** #21 — Docker + Caddy deployment
+
+### Why containerize?
+
+The project started as a cron-triggered script (`poll.sh`), but with the webhook listener (Issue #12), it became a long-running service. Long-running services need:
+
+1. **Process supervision** -- restart on crash (Docker's `restart: unless-stopped`)
+2. **TLS termination** -- GitHub webhook payloads should be delivered over HTTPS
+3. **Reproducible environment** -- Node 24+ requirement is enforced by the base image, not by documentation
+
+Docker Compose ties these together: the bot container runs the webhook listener, and Caddy handles TLS + reverse proxying.
+
+### Why Caddy over Nginx?
+
+Caddy provides **automatic HTTPS** out of the box. With Nginx, you need to set up certbot, configure cron for certificate renewal, write the TLS configuration manually, and handle the ACME challenge. Caddy does all of this with zero configuration beyond the domain name. For a learning project, this eliminates an entire category of ops complexity.
+
+### Design decisions
+
+**Single-stage Dockerfile.** A multi-stage build (build stage + runtime stage) is common for TypeScript projects that compile to JavaScript. We skip this because `tsx` runs TypeScript directly -- there is no build step. The image installs all dependencies (including devDependencies like `tsx` and `vitest`) because `tsx` is needed at runtime to execute TypeScript. This keeps the Dockerfile simple at the cost of a slightly larger image. A future optimization could move `tsx` to production dependencies and use `--prod`.
+
+**Corepack for pnpm.** Node 24 ships with corepack, which can install pnpm without a separate `npm install -g pnpm` step. This is cleaner than adding a global npm install and avoids version drift.
+
+**Health-gated startup.** The `docker-compose.yml` uses `depends_on: { bot: { condition: service_healthy } }` so Caddy only starts accepting traffic after the bot's `/health` endpoint responds. This prevents Caddy from proxying to a container that is not ready yet.
+
+**Volume mounts, not COPY.** `config.json` is mounted read-only at runtime, not copied into the image. This keeps credentials out of the Docker image layer history. `last_poll.json` and `issues/` are mounted read-write so state persists across container restarts.
+
+**.dockerignore.** Excludes `node_modules/` (rebuilt inside the container), `.git/` (large, not needed at runtime), `config.json` and `last_poll.json` (secrets and state), and test files (not needed in production). This keeps the build context small and avoids accidentally baking credentials into the image.
+
+### What this does NOT do
+
+- No CI/CD pipeline -- this is a deployment recipe, not an automated release system
+- No Docker registry push -- images are built locally on the server
+- No secrets management beyond file mounts -- a production system would use Docker secrets or a vault
+- No horizontal scaling -- single instance is sufficient for a learning project

--- a/README.md
+++ b/README.md
@@ -268,7 +268,81 @@ deepagents/
   poll.log            -- Generated: cron run logs (git-ignored)
   LEARNING_LOG.md     -- Project learning narrative
   CLAUDE.md           -- Claude Code project instructions
+  Dockerfile          -- Container image definition
+  docker-compose.yml  -- Bot + Caddy reverse proxy stack
+  Caddyfile           -- Caddy reverse proxy config (TLS termination)
+  .dockerignore       -- Files excluded from Docker build context
 ```
+
+## Docker Deployment
+
+Run the webhook listener behind Caddy with automatic HTTPS.
+
+### Prerequisites
+
+- [Docker](https://docs.docker.com/get-docker/) and Docker Compose
+- A domain name with DNS pointing to your server
+- `config.json` with valid credentials (see Setup above)
+
+### 1. Configure your domain
+
+Edit `Caddyfile` and replace `yourdomain.com` with your actual domain:
+
+```
+yourdomain.com {
+    reverse_proxy bot:3000
+}
+```
+
+Caddy will automatically provision a TLS certificate from Let's Encrypt.
+
+### 2. Create runtime files
+
+The bot needs `last_poll.json` and `issues/` to exist before mounting:
+
+```bash
+touch last_poll.json
+mkdir -p issues
+```
+
+### 3. Build and start
+
+```bash
+docker compose up -d --build
+```
+
+This starts two containers:
+- **bot** -- the webhook listener on port 3000 (internal only)
+- **caddy** -- reverse proxy on ports 80/443 with automatic TLS
+
+### 4. Verify
+
+```bash
+# Check container health
+docker compose ps
+
+# View bot logs
+docker compose logs -f bot
+
+# Test health endpoint
+curl https://yourdomain.com/health
+```
+
+### 5. Point GitHub webhook
+
+In your GitHub repo settings, add a webhook:
+- **Payload URL:** `https://yourdomain.com/webhook`
+- **Content type:** `application/json`
+- **Secret:** same value as `webhook.secret` in your `config.json`
+- **Events:** select "Issues" and "Pull requests"
+
+### Stopping
+
+```bash
+docker compose down
+```
+
+Caddy's TLS certificates persist in the `caddy_data` volume across restarts.
 
 ## How to Reset
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,36 @@
+services:
+  bot:
+    build: .
+    container_name: deepagents-bot
+    restart: unless-stopped
+    expose:
+      - "3000"
+    volumes:
+      - ./config.json:/app/config.json:ro
+      - ./last_poll.json:/app/last_poll.json
+      - ./issues:/app/issues
+    healthcheck:
+      test: ["CMD", "node", "-e", "fetch('http://localhost:3000/health').then(r=>{if(!r.ok)throw r.status}).catch(()=>process.exit(1))"]
+      interval: 30s
+      timeout: 5s
+      start_period: 10s
+      retries: 3
+
+  caddy:
+    image: caddy:2
+    container_name: deepagents-caddy
+    restart: unless-stopped
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy_data:/data
+      - caddy_config:/config
+    depends_on:
+      bot:
+        condition: service_healthy
+
+volumes:
+  caddy_data:
+  caddy_config:


### PR DESCRIPTION
## Summary

Adds containerized deployment with automatic HTTPS via Docker Compose + Caddy.

- **Dockerfile**: Node 24-slim base, pnpm via corepack, healthcheck against `/health`
- **docker-compose.yml**: two-service stack (bot + Caddy reverse proxy) with health-gated startup
- **Caddyfile**: reverse proxy with automatic TLS via Let's Encrypt (placeholder domain)
- **.dockerignore**: excludes node_modules, .git, credentials, tests, generated files
- **README**: "Docker Deployment" section with step-by-step setup instructions
- **CHANGELOG**: v0.6.1 entry
- **LEARNING_LOG**: Entry 42 on deployment design decisions

Closes #21

<!-- deep-agent-pr -->