### PR TITLE
Agent-human interactive dialog (#48, #49)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,26 @@
 
 ---
 
+## v1.2.0 — 2026-02-10
+
+**Agent-human interactive dialog (Issues #48, #49).** Humans can now chat directly with the agent via a web UI or API endpoint.
+
+### Added
+- **Chat agent** (`src/chat-agent.ts`) — conversational agent using the same LLM and read-only GitHub tools, with LangGraph `MemorySaver` checkpointer for multi-turn conversation state
+- **`/chat` POST endpoint** (Issue #48) — accepts `{ message, sessionId }`, returns agent response with conversation continuity per session
+- **`dialog.html`** (Issue #49) — vanilla HTML/CSS/JS chat UI served at `GET /`, dark theme, auto-resizing input, session management
+- **`createDialogApp()`** and **`startDialogServer()`** factories in `listener.ts`
+- **`deepagents dialog`** CLI subcommand with `--port N` option (default: 3001)
+- `pnpm dialog` script shorthand
+- `@langchain/langgraph` added as direct dependency (was transitive via deepagents)
+- 7 new tests in `tests/listener.test.ts`: health check, HTML serving, chat endpoint, validation, error handling
+
+### Changed
+- `listener.ts` imports `chat-agent.js` for the dialog endpoint
+- CLI help text updated with `dialog` command and examples
+
+---
+
 ## v1.1.0 — 2026-02-09
 
 **Consolidate configuration into `.env` as single source of truth (Issue #47).**

--- a/LEARNING_LOG.md
+++ b/LEARNING_LOG.md
@@ -5461,6 +5461,47 @@ The system prompt asks it to: read the diff, read relevant files, evaluate the a
 - `cli.ts`: New `review --pr N` subcommand
 - 12 new tests for the tools, 2 updated listener tests for reviewer integration
 
+## Entry 46: Agent-Human Interactive Dialog -- From Autonomous to Conversational (Issues #48, #49)
+
+**Date:** 2026-02-10
+**Author:** Builder Agent
+**Issues:** #48 (chat endpoint), #49 (dialog.html)
+**Builds on:** Entry 44 (Reviewer Bot), Entry 31 (Webhook Listener)
+
+### Why this design
+
+Until now, the agent was purely autonomous: it received GitHub events and acted on them without human interaction. But LangChain and the DeepAgents framework already have human-in-the-loop patterns built in — `createDeepAgent` accepts a `checkpointer` parameter for conversation state, and the agent's `invoke()` method supports `thread_id` for session isolation. We're not building something new; we're wiring up what's already there.
+
+### The pattern: LangGraph checkpointer for multi-turn chat
+
+The key insight is that LangGraph's `MemorySaver` gives us conversation state for free. Each session gets a `thread_id`, and the checkpointer automatically accumulates messages across invocations:
+
+```typescript
+const agent = createDeepAgent({ model, tools, systemPrompt, checkpointer });
+
+// Each call with the same thread_id continues the conversation
+await agent.invoke(
+  { messages: [{ role: 'user', content: 'What does this project do?' }] },
+  { configurable: { thread_id: sessionId } },
+);
+```
+
+No custom message history management, no database — the framework handles it.
+
+### What could go wrong
+
+- **Memory grows unbounded** — `MemorySaver` is in-memory, so long sessions or many concurrent sessions will consume memory. For a learning project this is fine; production would need a persistent checkpointer (SQLite, PostgreSQL).
+- **Agent creates new tools per request** — `createChatAgent()` is called per chat message, which creates fresh Octokit clients and tool instances. This is intentional for simplicity and matches the existing pattern (analysis agent is also created per invocation). If latency becomes an issue, agent instances could be cached per session.
+- **Circuit breaker is per-invocation** — each chat turn gets a fresh 15-call budget. A user can't exhaust the circuit breaker across turns, which is the right behavior for interactive use.
+
+### Connections to previous entries
+
+- **Entry 31** (Webhook Listener): The dialog server reuses the same Express pattern — `createDialogApp()` mirrors `createWebhookApp()`. Both are testable factories that return an Express app.
+- **Entry 44** (Reviewer Bot): The chat agent uses the same `createModel()` and read-only tool factories, following the established pattern of agent-specific tool subsets.
+- **Entry 16** (Test Infrastructure): The dialog tests reuse the same `inject()` HTTP helper pattern from webhook tests — no supertest dependency.
+
+---
+
 ## Entry 45: Consolidating Config into .env -- Single Source of Truth (Issue #47)
 
 **Date:** 2026-02-09

--- a/README.md
+++ b/README.md
@@ -216,6 +216,7 @@ Choose the mode that fits your use case:
 |------|----------|--------------|
 | **Cron polling** | Simple, low-volume repos | Cron job runs `poll.sh` on a schedule |
 | **Webhook (local)** | Development / testing | `pnpm webhook` listens for GitHub events |
+| **Dialog** | Interactive chat | `pnpm dialog` opens a web UI for human-agent conversation |
 | **Docker + Caddy** | Production deployment | Containerized webhook listener with auto-HTTPS |
 
 ### Cron polling
@@ -278,6 +279,27 @@ pnpm webhook
 
 The server exposes two endpoints:
 - `POST /webhook` — receives GitHub events (verified with HMAC-SHA256)
+- `GET /health` — returns `{ "status": "ok" }`
+
+### Interactive dialog (chat)
+
+Chat directly with the agent via a web UI. The agent has read-only access to the repository — it can browse files, list issues, and answer questions about the codebase.
+
+```bash
+pnpm dialog
+```
+
+Open http://localhost:3001/ in your browser. The chat UI supports multi-turn conversations with session state.
+
+To use a different port:
+
+```bash
+pnpm run cli dialog --port 8080
+```
+
+The dialog server exposes three endpoints:
+- `GET /` — serves the chat UI (`dialog.html`)
+- `POST /chat` — accepts `{ message, sessionId }`, returns `{ response, sessionId }`
 - `GET /health` — returns `{ "status": "ok" }`
 
 ### Docker deployment
@@ -434,6 +456,10 @@ pnpm run cli retract --issue 42
 # Start webhook listener (real-time, replaces cron)
 pnpm run cli webhook
 
+# Start the interactive dialog (chat with the agent)
+pnpm run cli dialog
+pnpm run cli dialog --port 8080
+
 # Show current polling state
 pnpm run cli status
 
@@ -453,7 +479,7 @@ pnpm test
 pnpm run test:watch
 ```
 
-259 tests across 9 test files using [vitest](https://vitest.dev/) with mocked external dependencies (Octokit, LLM constructors, filesystem). No real API calls are made during testing.
+266 tests across 9 test files using [vitest](https://vitest.dev/) with mocked external dependencies (Octokit, LLM constructors, filesystem). No real API calls are made during testing.
 
 ## Troubleshooting
 
@@ -490,7 +516,8 @@ learning-deep-agents/
     reviewer-agent.ts -- PR reviewer agent (diff reader, source context, review submitter)
     logger.ts         -- Structured logging wrapper for tool calls
     utils.ts          -- Retry with exponential backoff for API calls
-    listener.ts       -- Express webhook server with HMAC-SHA256 verification
+    chat-agent.ts     -- Chat agent for human-agent interaction (read-only tools + checkpointer)
+    listener.ts       -- Express webhook server, dialog server, HMAC-SHA256 verification
   tests/
     core.test.ts      -- Unit tests for core logic, state, graceful shutdown
     github-tools.test.ts -- Idempotency and tool tests (mocked Octokit)
@@ -502,6 +529,8 @@ learning-deep-agents/
     utils.test.ts     -- Retry logic and error classification tests
     listener.test.ts  -- Webhook endpoint and signature verification tests
   issues/             -- Generated: detailed analysis files
+  static/
+    dialog.html       -- Chat UI for testing agent-human interaction
   .env                -- Your credentials and settings (git-ignored, single source of truth)
   .env.example        -- Comprehensive template for .env
   last_poll.json      -- Generated: polling state (git-ignored)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -158,6 +158,7 @@ Incremental improvements after the v1.0.0 milestone. These are not new phases �
 | Version | Change | Status |
 |---------|--------|--------|
 | v1.1.0 | Consolidate config into `.env` as single source of truth (#47) | ✓ v1.1.0 |
+| v1.2.0 | Agent-human interactive dialog (#48, #49) | ✓ v1.2.0 |
 
 ---
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,8 +27,8 @@ services:
     restart: unless-stopped
     env_file: .env
     ports:
-      - "80:80"
-      - "443:443"
+      - "11180:80"
+      - "11443:443"
     volumes:
       - ./Caddyfile:/etc/caddy/Caddyfile:ro
       - caddy_data:/data

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "deepagents-github-test",
-  "version": "1.0.0",
+  "version": "1.2.0",
   "description": "Simple test to learn Deep Agents workflow with GitHub issues",
   "type": "module",
   "bin": {
@@ -15,10 +15,12 @@
     "cli": "tsx src/cli.ts",
     "test": "vitest run",
     "test:watch": "vitest",
-    "webhook": "tsx src/cli.ts webhook"
+    "webhook": "tsx src/cli.ts webhook",
+    "dialog": "tsx src/cli.ts dialog"
   },
   "dependencies": {
     "@langchain/anthropic": "^1.3.0",
+    "@langchain/langgraph": "^1.1.4",
     "@langchain/ollama": "^1.2.2",
     "@langchain/openai": "^1.2.0",
     "@octokit/auth-app": "^8.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@langchain/anthropic':
         specifier: ^1.3.0
         version: 1.3.15(@langchain/core@1.1.19(openai@6.18.0(zod@3.25.76)))
+      '@langchain/langgraph':
+        specifier: ^1.1.4
+        version: 1.1.4(@langchain/core@1.1.19(openai@6.18.0(zod@3.25.76)))(zod@3.25.76)
       '@langchain/ollama':
         specifier: ^1.2.2
         version: 1.2.2(@langchain/core@1.1.19(openai@6.18.0(zod@3.25.76)))

--- a/src/chat-agent.ts
+++ b/src/chat-agent.ts
@@ -1,0 +1,113 @@
+import { createDeepAgent } from 'deepagents';
+import { MemorySaver } from '@langchain/langgraph';
+import type { Config } from './config.js';
+import { createModel } from './model.js';
+import {
+  createGitHubClient,
+  getAuthFromConfig,
+  createGitHubIssuesTool,
+  createListRepoFilesTool,
+  createReadRepoFileTool,
+  wrapWithCircuitBreaker,
+  ToolCallCounter,
+} from './github-tools.js';
+import { wrapWithLogging } from './logger.js';
+
+/**
+ * Maximum tool calls per chat turn to prevent runaway loops.
+ */
+const CHAT_MAX_TOOL_CALLS = 15;
+
+/**
+ * In-memory checkpointer for multi-turn conversation state.
+ * Shared across all sessions within a single process.
+ */
+const checkpointer = new MemorySaver();
+
+/**
+ * Create a chat agent that humans can interact with directly.
+ *
+ * Uses the same LLM and read-only GitHub tools as the analysis agent,
+ * but with a conversational system prompt and LangGraph checkpointer
+ * for multi-turn conversation state.
+ */
+export function createChatAgent(config: Config) {
+  const model = createModel(config);
+  const { owner, repo } = config.github;
+  const octokit = createGitHubClient(getAuthFromConfig(config.github));
+
+  // Read-only tools — the chat agent can browse but not write
+  let issuesTool = createGitHubIssuesTool(owner, repo, octokit);
+  let listFilesTool = createListRepoFilesTool(owner, repo, octokit);
+  let readFileTool = createReadRepoFileTool(owner, repo, octokit);
+
+  // Circuit breaker per turn
+  const counter = new ToolCallCounter(CHAT_MAX_TOOL_CALLS);
+  issuesTool = wrapWithCircuitBreaker(issuesTool, counter);
+  listFilesTool = wrapWithCircuitBreaker(listFilesTool, counter);
+  readFileTool = wrapWithCircuitBreaker(readFileTool, counter);
+
+  // Logging
+  issuesTool = wrapWithLogging(issuesTool, counter);
+  listFilesTool = wrapWithLogging(listFilesTool, counter);
+  readFileTool = wrapWithLogging(readFileTool, counter);
+
+  const systemPrompt = `You are a helpful assistant for the GitHub repository ${owner}/${repo}.
+
+You can browse the repository to answer questions about the codebase, issues, and project structure.
+You have read-only access — you cannot modify code, create branches, or post comments.
+
+Available tools:
+- fetch_github_issues: Fetch open issues from the repo
+- list_repo_files: List files in the repo (supports path prefix filtering)
+- read_repo_file: Read a file's contents from the repo
+
+When answering questions:
+- Use the tools to look up actual code and issues rather than guessing
+- Be concise and direct
+- Reference specific files and line numbers when discussing code
+`;
+
+  const agent = createDeepAgent({
+    model,
+    tools: [issuesTool, listFilesTool, readFileTool],
+    systemPrompt,
+    checkpointer,
+  });
+
+  return agent;
+}
+
+/**
+ * Result of a single chat turn.
+ */
+export interface ChatResult {
+  response: string;
+  sessionId: string;
+}
+
+/**
+ * Send a message to the chat agent and get a response.
+ * Conversation state is maintained per sessionId via the checkpointer.
+ */
+export async function chat(
+  config: Config,
+  message: string,
+  sessionId: string,
+): Promise<ChatResult> {
+  const agent = createChatAgent(config);
+
+  const result = await agent.invoke(
+    { messages: [{ role: 'user', content: message }] },
+    { configurable: { thread_id: sessionId } },
+  );
+
+  // Extract the last AI message
+  const messages = result.messages ?? [];
+  const lastMessage = messages[messages.length - 1];
+  const response = typeof lastMessage?.content === 'string'
+    ? lastMessage.content
+    : JSON.stringify(lastMessage?.content ?? '');
+
+  return { response, sessionId };
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,7 +3,7 @@ import 'dotenv/config';
 
 import { loadConfig } from './config.js';
 import { runPollCycle, runAnalyzeSingle, runTriageSingle, showStatus, retractIssue, requestShutdown } from './core.js';
-import { startWebhookServer } from './listener.js';
+import { startWebhookServer, startDialogServer } from './listener.js';
 import { runReviewSingle } from './reviewer-agent.js';
 
 // ── Signal handlers for graceful shutdown ────────────────────────────────────
@@ -39,6 +39,7 @@ Commands:
   review            Review a pull request (fetch diff, analyze, post review comment)
   retract           Undo agent actions on an issue (close PR, delete branch, delete comment)
   webhook           Start the HTTP webhook listener for GitHub events
+  dialog            Start the interactive chat server (agent + human conversation)
   status            Show current polling state
   help              Show this help message
 
@@ -60,6 +61,9 @@ Options for 'review':
 Options for 'retract':
   --issue N         Issue number to retract (required)
 
+Options for 'dialog':
+  --port N          Port for the dialog server (default: 3001)
+
 Examples:
   deepagents poll
   deepagents poll --dry-run
@@ -70,6 +74,8 @@ Examples:
   deepagents review --pr 10
   deepagents retract --issue 42
   deepagents webhook
+  deepagents dialog
+  deepagents dialog --port 8080
   deepagents status
 `.trim();
 
@@ -93,6 +99,8 @@ function parseArgs(argv: string[]): { command: string; flags: Record<string, str
       flags['issue'] = args[++i];
     } else if (arg === '--pr' && i + 1 < args.length) {
       flags['pr'] = args[++i];
+    } else if (arg === '--port' && i + 1 < args.length) {
+      flags['port'] = args[++i];
     } else {
       console.error(`Unknown option: ${arg}`);
       console.log(USAGE);
@@ -234,6 +242,21 @@ async function main() {
       }
       console.log('\u{1F916} Deep Agents Webhook Listener\n');
       startWebhookServer(config.webhook, config);
+      // Server runs until process is killed (SIGTERM/SIGINT)
+      break;
+    }
+
+    case 'dialog': {
+      const portStr = flags['port'];
+      const port = typeof portStr === 'string' ? parseInt(portStr, 10) : 3001;
+
+      if (isNaN(port) || port < 1 || port > 65535) {
+        console.error('--port must be a number between 1 and 65535');
+        process.exit(1);
+      }
+
+      console.log('\u{1F916} Deep Agents Interactive Dialog\n');
+      startDialogServer(config, port);
       // Server runs until process is killed (SIGTERM/SIGINT)
       break;
     }

--- a/src/listener.ts
+++ b/src/listener.ts
@@ -1,9 +1,12 @@
 import { createHmac, timingSafeEqual } from 'crypto';
+import path from 'path';
+import { fileURLToPath } from 'url';
 import express from 'express';
 import type { Request, Response } from 'express';
 import type { Config } from './config.js';
 import { runAnalyzeSingle } from './core.js';
 import { runReviewSingle } from './reviewer-agent.js';
+import { chat } from './chat-agent.js';
 
 /**
  * Webhook listener configuration.
@@ -327,6 +330,83 @@ export function startWebhookServer(config: WebhookConfig, fullConfig?: Config) {
     console.log(`[webhook] Health check: http://localhost:${config.port}/health`);
     console.log(`[webhook] Webhook URL:  http://localhost:${config.port}/webhook`);
     console.log('[webhook] Waiting for GitHub events...\n');
+  });
+
+  return server;
+}
+
+// ── Dialog (chat) server ─────────────────────────────────────────────────────
+
+/**
+ * Resolve the path to the static/ directory relative to this file.
+ */
+function getStaticDir(): string {
+  const __dirname = path.dirname(fileURLToPath(import.meta.url));
+  return path.resolve(__dirname, '..', 'static');
+}
+
+/**
+ * Create an Express app for the interactive dialog (chat) interface.
+ *
+ * Endpoints:
+ * - GET  /health  — health check
+ * - GET  /        — serves dialog.html
+ * - POST /chat    — sends a message to the chat agent, returns the response
+ */
+export function createDialogApp(config: Config): express.Express {
+  const app = express();
+
+  app.use(express.json());
+
+  // Health check
+  app.get('/health', (_req: Request, res: Response) => {
+    res.json({ status: 'ok', timestamp: new Date().toISOString() });
+  });
+
+  // Serve dialog.html at root
+  app.get('/', (_req: Request, res: Response) => {
+    res.sendFile(path.join(getStaticDir(), 'dialog.html'));
+  });
+
+  // Chat endpoint
+  app.post('/chat', async (req: Request, res: Response) => {
+    const { message, sessionId } = req.body as { message?: string; sessionId?: string };
+
+    if (!message || typeof message !== 'string') {
+      res.status(400).json({ error: 'Missing or invalid "message" field' });
+      return;
+    }
+
+    const sid = sessionId || crypto.randomUUID();
+
+    console.log(`[chat] Session ${sid}: "${message.slice(0, 80)}${message.length > 80 ? '...' : ''}"`);
+
+    try {
+      const result = await chat(config, message, sid);
+      res.json({ response: result.response, sessionId: result.sessionId });
+    } catch (err) {
+      console.error(`[chat] Error for session ${sid}:`, err);
+      res.status(500).json({ error: 'Chat agent failed' });
+    }
+  });
+
+  return app;
+}
+
+/**
+ * Start the dialog (chat) HTTP server.
+ *
+ * Returns the HTTP server instance for graceful shutdown.
+ */
+export function startDialogServer(config: Config, port: number) {
+  const app = createDialogApp(config);
+
+  const server = app.listen(port, () => {
+    console.log(`[dialog] Listening on port ${port}`);
+    console.log(`[dialog] Chat UI:      http://localhost:${port}/`);
+    console.log(`[dialog] Chat API:     http://localhost:${port}/chat`);
+    console.log(`[dialog] Health check: http://localhost:${port}/health`);
+    console.log('[dialog] Ready for conversations.\n');
   });
 
   return server;

--- a/static/dialog.html
+++ b/static/dialog.html
@@ -1,0 +1,205 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Deep Agents Dialog</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, monospace;
+      background: #1a1a2e;
+      color: #e0e0e0;
+      height: 100vh;
+      display: flex;
+      flex-direction: column;
+    }
+
+    header {
+      padding: 12px 20px;
+      background: #16213e;
+      border-bottom: 1px solid #0f3460;
+      display: flex;
+      align-items: center;
+      gap: 12px;
+    }
+
+    header h1 { font-size: 16px; font-weight: 600; }
+    header .session {
+      font-size: 11px;
+      color: #888;
+      margin-left: auto;
+      font-family: monospace;
+    }
+
+    #messages {
+      flex: 1;
+      overflow-y: auto;
+      padding: 20px;
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+    }
+
+    .msg {
+      max-width: 80%;
+      padding: 10px 14px;
+      border-radius: 8px;
+      line-height: 1.5;
+      white-space: pre-wrap;
+      word-break: break-word;
+      font-size: 14px;
+    }
+
+    .msg.user {
+      align-self: flex-end;
+      background: #0f3460;
+      color: #e0e0e0;
+    }
+
+    .msg.agent {
+      align-self: flex-start;
+      background: #16213e;
+      border: 1px solid #0f3460;
+    }
+
+    .msg.error {
+      align-self: center;
+      background: #3d0000;
+      border: 1px solid #6b0000;
+      color: #ff6b6b;
+      font-size: 12px;
+    }
+
+    .msg.thinking {
+      align-self: flex-start;
+      background: transparent;
+      color: #888;
+      font-style: italic;
+      padding: 4px 14px;
+      font-size: 13px;
+    }
+
+    #input-area {
+      padding: 12px 20px;
+      background: #16213e;
+      border-top: 1px solid #0f3460;
+      display: flex;
+      gap: 8px;
+    }
+
+    #input {
+      flex: 1;
+      padding: 10px 14px;
+      background: #1a1a2e;
+      border: 1px solid #0f3460;
+      border-radius: 6px;
+      color: #e0e0e0;
+      font-size: 14px;
+      font-family: inherit;
+      outline: none;
+      resize: none;
+    }
+
+    #input:focus { border-color: #533483; }
+
+    #send {
+      padding: 10px 20px;
+      background: #533483;
+      color: white;
+      border: none;
+      border-radius: 6px;
+      cursor: pointer;
+      font-size: 14px;
+      font-family: inherit;
+    }
+
+    #send:hover { background: #6b44a0; }
+    #send:disabled { background: #333; cursor: not-allowed; }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Deep Agents Dialog</h1>
+    <span class="session" id="session-display"></span>
+  </header>
+
+  <div id="messages"></div>
+
+  <div id="input-area">
+    <textarea id="input" rows="1" placeholder="Ask about the codebase..." autofocus></textarea>
+    <button id="send">Send</button>
+  </div>
+
+  <script>
+    const sessionId = crypto.randomUUID();
+    document.getElementById('session-display').textContent = 'session: ' + sessionId.slice(0, 8);
+
+    const messagesEl = document.getElementById('messages');
+    const inputEl = document.getElementById('input');
+    const sendBtn = document.getElementById('send');
+
+    function addMessage(text, cls) {
+      const div = document.createElement('div');
+      div.className = 'msg ' + cls;
+      div.textContent = text;
+      messagesEl.appendChild(div);
+      messagesEl.scrollTop = messagesEl.scrollHeight;
+      return div;
+    }
+
+    async function send() {
+      const message = inputEl.value.trim();
+      if (!message) return;
+
+      inputEl.value = '';
+      inputEl.style.height = 'auto';
+      addMessage(message, 'user');
+
+      sendBtn.disabled = true;
+      const thinking = addMessage('Thinking...', 'thinking');
+
+      try {
+        const res = await fetch('/chat', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ message, sessionId }),
+        });
+
+        thinking.remove();
+
+        if (!res.ok) {
+          const err = await res.json().catch(() => ({ error: res.statusText }));
+          addMessage('Error: ' + (err.error || res.statusText), 'error');
+          return;
+        }
+
+        const data = await res.json();
+        addMessage(data.response, 'agent');
+      } catch (err) {
+        thinking.remove();
+        addMessage('Network error: ' + err.message, 'error');
+      } finally {
+        sendBtn.disabled = false;
+        inputEl.focus();
+      }
+    }
+
+    sendBtn.addEventListener('click', send);
+
+    inputEl.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter' && !e.shiftKey) {
+        e.preventDefault();
+        send();
+      }
+    });
+
+    // Auto-resize textarea
+    inputEl.addEventListener('input', () => {
+      inputEl.style.height = 'auto';
+      inputEl.style.height = Math.min(inputEl.scrollHeight, 120) + 'px';
+    });
+  </script>
+</body>
+</html>

--- a/tests/listener.test.ts
+++ b/tests/listener.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { createHmac } from 'crypto';
 import {
   createWebhookApp,
+  createDialogApp,
   verifySignature,
   handlePullRequestEvent,
   handleWebhookEvent,
@@ -19,8 +20,13 @@ vi.mock('../src/reviewer-agent.js', () => ({
   runReviewSingle: vi.fn().mockResolvedValue(undefined),
 }));
 
+vi.mock('../src/chat-agent.js', () => ({
+  chat: vi.fn().mockResolvedValue({ response: 'mock response', sessionId: 'test-session' }),
+}));
+
 import { runAnalyzeSingle } from '../src/core.js';
 import { runReviewSingle } from '../src/reviewer-agent.js';
+import { chat } from '../src/chat-agent.js';
 
 // ── verifySignature ──────────────────────────────────────────────────────────
 
@@ -612,6 +618,151 @@ describe('handleIssuesEvent', () => {
     expect(result.issueNumber).toBe(99);
     expect(console.error).toHaveBeenCalledWith(
       expect.stringContaining('Analysis failed'),
+      expect.any(Error),
+    );
+  });
+});
+
+// ── createDialogApp ─────────────────────────────────────────────────────────
+
+describe('createDialogApp', () => {
+  const mockConfig = {
+    github: { owner: 'owner', repo: 'repo', token: 'ghp_test' },
+    llm: { provider: 'anthropic', apiKey: 'sk-test', model: 'claude-sonnet' },
+  } as any;
+
+  /**
+   * Inject a request into the Express app and capture the response.
+   */
+  async function inject(
+    app: ReturnType<typeof createDialogApp>,
+    method: string,
+    path: string,
+    opts: { body?: string; headers?: Record<string, string> } = {},
+  ): Promise<{ status: number; body: any; headers: Record<string, string> }> {
+    const { default: http } = await import('http');
+
+    return new Promise((resolve, reject) => {
+      const server = app.listen(0, () => {
+        const addr = server.address();
+        if (!addr || typeof addr === 'string') { server.close(); reject(new Error('bad addr')); return; }
+
+        const req = http.request(
+          {
+            hostname: '127.0.0.1',
+            port: addr.port,
+            path,
+            method,
+            headers: {
+              ...(opts.body ? { 'content-type': 'application/json' } : {}),
+              ...opts.headers,
+            },
+          },
+          (res) => {
+            let data = '';
+            res.on('data', (chunk) => { data += chunk; });
+            res.on('end', () => {
+              server.close();
+              const respHeaders: Record<string, string> = {};
+              for (const [k, v] of Object.entries(res.headers)) {
+                if (typeof v === 'string') respHeaders[k] = v;
+              }
+              try {
+                resolve({ status: res.statusCode!, body: JSON.parse(data), headers: respHeaders });
+              } catch {
+                resolve({ status: res.statusCode!, body: data, headers: respHeaders });
+              }
+            });
+          },
+        );
+
+        req.on('error', (err) => { server.close(); reject(err); });
+        if (opts.body) req.write(opts.body);
+        req.end();
+      });
+    });
+  }
+
+  beforeEach(() => {
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.mocked(chat).mockReset().mockResolvedValue({ response: 'Hello from agent', sessionId: 'sess-1' });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('GET /health returns 200', async () => {
+    const app = createDialogApp(mockConfig);
+    const res = await inject(app, 'GET', '/health');
+
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe('ok');
+  });
+
+  it('GET / serves dialog.html', async () => {
+    const app = createDialogApp(mockConfig);
+    const res = await inject(app, 'GET', '/');
+
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toContain('text/html');
+  });
+
+  it('POST /chat returns agent response for valid message', async () => {
+    const app = createDialogApp(mockConfig);
+    const res = await inject(app, 'POST', '/chat', {
+      body: JSON.stringify({ message: 'What does this project do?', sessionId: 'test-session' }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body.response).toBe('Hello from agent');
+    expect(res.body.sessionId).toBe('sess-1');
+    expect(chat).toHaveBeenCalledWith(mockConfig, 'What does this project do?', 'test-session');
+  });
+
+  it('POST /chat returns 400 when message is missing', async () => {
+    const app = createDialogApp(mockConfig);
+    const res = await inject(app, 'POST', '/chat', {
+      body: JSON.stringify({ sessionId: 'test-session' }),
+    });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain('Missing');
+  });
+
+  it('POST /chat returns 400 when message is empty string', async () => {
+    const app = createDialogApp(mockConfig);
+    const res = await inject(app, 'POST', '/chat', {
+      body: JSON.stringify({ message: '', sessionId: 'test-session' }),
+    });
+
+    expect(res.status).toBe(400);
+  });
+
+  it('POST /chat generates sessionId when not provided', async () => {
+    const app = createDialogApp(mockConfig);
+    const res = await inject(app, 'POST', '/chat', {
+      body: JSON.stringify({ message: 'Hello' }),
+    });
+
+    expect(res.status).toBe(200);
+    // chat() should have been called with some generated UUID
+    expect(chat).toHaveBeenCalledWith(mockConfig, 'Hello', expect.any(String));
+  });
+
+  it('POST /chat returns 500 when chat agent throws', async () => {
+    vi.mocked(chat).mockRejectedValueOnce(new Error('LLM down'));
+
+    const app = createDialogApp(mockConfig);
+    const res = await inject(app, 'POST', '/chat', {
+      body: JSON.stringify({ message: 'Hello', sessionId: 's1' }),
+    });
+
+    expect(res.status).toBe(500);
+    expect(res.body.error).toBe('Chat agent failed');
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining('Error for session s1'),
       expect.any(Error),
     );
   });


### PR DESCRIPTION
## Summary
- **Chat endpoint** (`POST /chat`): Multi-turn conversation with the agent using LangGraph MemorySaver for session persistence. Read-only GitHub tools (issues, list files, read file) with 15-call circuit breaker.
- **Dialog UI** (`static/dialog.html`): Vanilla HTML/CSS/JS dark-theme chat interface served at `GET /`. Auto-resizing textarea, session isolation via `crypto.randomUUID()`.
- **CLI command**: `deepagents dialog [--port N]` starts the dialog server (default port 3001).
- **Port remap**: docker-compose ports updated to 11180:80 and 11443:443.

Closes #48, Closes #49

## Test plan
- [x] 7 new tests for dialog app (health, HTML, chat success, missing/empty message 400s, auto sessionId, agent error 500)
- [x] All 266 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)