### PR TITLE
SSE streaming with thinking display and token usage (#51)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,24 @@
 
 ---
 
+## v1.2.1 — 2026-02-10
+
+**SSE streaming with thinking display and token usage (Issue #51).** The dialog UI now shows agent reasoning in real-time.
+
+### Added
+- **`chatStream()` async generator** in `chat-agent.ts` — streams `tool_start`, `tool_end`, `response`, `usage`, and `error` events via LangGraph `streamEvents()` API
+- **Collapsible "Thinking" block** in dialog UI — shows each tool call name, args, and result as they happen
+- **Token usage badge** — displays input/output/total token counts after each response
+- **Pulsing status indicator** — shows what the agent is currently doing (e.g., "Calling list_repo_files...")
+- 1 new test for tool call streaming events (267 total)
+
+### Changed
+- `/chat` endpoint switched from single JSON response to SSE (`text/event-stream`) format
+- Dialog UI reads SSE stream via fetch + ReadableStream instead of awaiting JSON
+- Thinking block auto-collapses after response arrives
+
+---
+
 ## v1.2.0 — 2026-02-10
 
 **Agent-human interactive dialog (Issues #48, #49).** Humans can now chat directly with the agent via a web UI or API endpoint.

--- a/LEARNING_LOG.md
+++ b/LEARNING_LOG.md
@@ -5461,6 +5461,38 @@ The system prompt asks it to: read the diff, read relevant files, evaluate the a
 - `cli.ts`: New `review --pr N` subcommand
 - 12 new tests for the tools, 2 updated listener tests for reviewer integration
 
+## Entry 47: SSE Streaming -- Making the Agent's Thinking Visible (Issue #51)
+
+**Date:** 2026-02-10
+**Author:** Builder Agent
+**Issue:** #51 (SSE streaming with thinking and token usage)
+**Builds on:** Entry 46 (Agent-Human Interactive Dialog)
+
+### The problem
+
+The v1.2.0 dialog sent a single JSON response after the agent finished. For simple questions this was fine, but when the agent called multiple tools (fetching issues, reading files), the UI showed "Thinking..." for 10+ seconds with no feedback. Worse, if the LLM call failed silently, the user saw nothing — just an eternal spinner.
+
+### The fix: Server-Sent Events
+
+LangGraph's compiled graph exposes `.streamEvents()` which emits fine-grained events as the agent runs. We pipe these through SSE:
+
+1. `chatStream()` async generator yields typed events (`tool_start`, `tool_end`, `response`, `usage`, `error`)
+2. The `/chat` endpoint writes each event as `data: {...}\n\n`
+3. The frontend reads the stream via `fetch()` + `ReadableStream` and renders each event as it arrives
+
+Token usage is extracted from `on_chat_model_end` events where `usage_metadata` contains input/output counts. These accumulate across multiple LLM calls (tool-calling loop) and are yielded as a final `usage` event.
+
+### UI changes
+
+The dialog now has a collapsible "Thinking" block that shows each tool call with its arguments and result. It auto-collapses after the response arrives, keeping the chat clean. A pulsing status line shows what the agent is currently doing ("Calling list_repo_files...").
+
+### Connections to previous entries
+
+- **Entry 46** (Interactive Dialog): This directly improves the chat experience built there.
+- **Entry 33** (Structured Logging): The server-side logging still works alongside SSE — tool calls are logged to stdout and streamed to the client simultaneously.
+
+---
+
 ## Entry 46: Agent-Human Interactive Dialog -- From Autonomous to Conversational (Issues #48, #49)
 
 **Date:** 2026-02-10

--- a/README.md
+++ b/README.md
@@ -479,7 +479,7 @@ pnpm test
 pnpm run test:watch
 ```
 
-266 tests across 9 test files using [vitest](https://vitest.dev/) with mocked external dependencies (Octokit, LLM constructors, filesystem). No real API calls are made during testing.
+267 tests across 9 test files using [vitest](https://vitest.dev/) with mocked external dependencies (Octokit, LLM constructors, filesystem). No real API calls are made during testing.
 
 ## Troubleshooting
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -159,6 +159,7 @@ Incremental improvements after the v1.0.0 milestone. These are not new phases �
 |---------|--------|--------|
 | v1.1.0 | Consolidate config into `.env` as single source of truth (#47) | ✓ v1.1.0 |
 | v1.2.0 | Agent-human interactive dialog (#48, #49) | ✓ v1.2.0 |
+| v1.2.1 | SSE streaming with thinking display and token usage (#51) | ✓ v1.2.1 |
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "deepagents-github-test",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Simple test to learn Deep Agents workflow with GitHub issues",
   "type": "module",
   "bin": {

--- a/src/chat-agent.ts
+++ b/src/chat-agent.ts
@@ -79,7 +79,20 @@ When answering questions:
 }
 
 /**
- * Result of a single chat turn.
+ * SSE event emitted during chat streaming.
+ */
+export interface ChatEvent {
+  type: 'tool_start' | 'tool_end' | 'response' | 'usage' | 'error';
+  name?: string;
+  args?: Record<string, unknown>;
+  result?: string;
+  text?: string;
+  tokens?: { input: number; output: number; total: number };
+  message?: string;
+}
+
+/**
+ * Result of a single chat turn (non-streaming, used by tests).
  */
 export interface ChatResult {
   response: string;
@@ -110,4 +123,59 @@ export async function chat(
     : JSON.stringify(lastMessage?.content ?? '');
 
   return { response, sessionId };
+}
+
+/**
+ * Stream chat events from the agent. Yields tool calls, the final
+ * response, and token usage as they happen — consumed by the SSE endpoint.
+ */
+export async function* chatStream(
+  config: Config,
+  message: string,
+  sessionId: string,
+): AsyncGenerator<ChatEvent> {
+  const agent = createChatAgent(config);
+  let totalInput = 0;
+  let totalOutput = 0;
+  let lastResponse = '';
+
+  try {
+    const stream = agent.streamEvents(
+      { messages: [{ role: 'user', content: message }] },
+      { configurable: { thread_id: sessionId }, version: 'v2' },
+    );
+
+    for await (const ev of stream) {
+      if (ev.event === 'on_tool_start') {
+        yield { type: 'tool_start', name: ev.name, args: ev.data?.input };
+      } else if (ev.event === 'on_tool_end') {
+        const out = ev.data?.output;
+        const txt = typeof out === 'string' ? out : JSON.stringify(out ?? '');
+        yield { type: 'tool_end', name: ev.name, result: txt.slice(0, 1000) };
+      } else if (ev.event === 'on_chat_model_end') {
+        const usage = ev.data?.output?.usage_metadata;
+        if (usage) {
+          totalInput += usage.input_tokens ?? 0;
+          totalOutput += usage.output_tokens ?? 0;
+        }
+        const content = ev.data?.output?.content;
+        if (typeof content === 'string' && content) {
+          lastResponse = content;
+        }
+      }
+    }
+
+    if (lastResponse) {
+      yield { type: 'response', text: lastResponse };
+    }
+
+    yield {
+      type: 'usage',
+      tokens: { input: totalInput, output: totalOutput, total: totalInput + totalOutput },
+    };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error(`[chat-stream] Error:`, err);
+    yield { type: 'error', message: msg };
+  }
 }

--- a/src/listener.ts
+++ b/src/listener.ts
@@ -6,7 +6,7 @@ import type { Request, Response } from 'express';
 import type { Config } from './config.js';
 import { runAnalyzeSingle } from './core.js';
 import { runReviewSingle } from './reviewer-agent.js';
-import { chat } from './chat-agent.js';
+import { chat, chatStream } from './chat-agent.js';
 
 /**
  * Webhook listener configuration.
@@ -368,7 +368,7 @@ export function createDialogApp(config: Config): express.Express {
     res.sendFile(path.join(getStaticDir(), 'dialog.html'));
   });
 
-  // Chat endpoint
+  // Chat endpoint — SSE stream with thinking, response, and token usage
   app.post('/chat', async (req: Request, res: Response) => {
     const { message, sessionId } = req.body as { message?: string; sessionId?: string };
 
@@ -381,13 +381,24 @@ export function createDialogApp(config: Config): express.Express {
 
     console.log(`[chat] Session ${sid}: "${message.slice(0, 80)}${message.length > 80 ? '...' : ''}"`);
 
+    // SSE headers
+    res.writeHead(200, {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache',
+      'Connection': 'keep-alive',
+    });
+
     try {
-      const result = await chat(config, message, sid);
-      res.json({ response: result.response, sessionId: result.sessionId });
+      for await (const event of chatStream(config, message, sid)) {
+        res.write(`data: ${JSON.stringify(event)}\n\n`);
+      }
     } catch (err) {
       console.error(`[chat] Error for session ${sid}:`, err);
-      res.status(500).json({ error: 'Chat agent failed' });
+      res.write(`data: ${JSON.stringify({ type: 'error', message: 'Chat agent failed' })}\n\n`);
     }
+
+    res.write('data: [DONE]\n\n');
+    res.end();
   });
 
   return app;

--- a/static/dialog.html
+++ b/static/dialog.html
@@ -72,13 +72,77 @@
       font-size: 12px;
     }
 
-    .msg.thinking {
+    .msg.thinking-status {
       align-self: flex-start;
       background: transparent;
       color: #888;
       font-style: italic;
       padding: 4px 14px;
       font-size: 13px;
+    }
+
+    /* Thinking block — collapsible tool calls */
+    .thinking-block {
+      align-self: flex-start;
+      max-width: 80%;
+      font-size: 12px;
+    }
+
+    .thinking-block summary {
+      cursor: pointer;
+      color: #7b6ba0;
+      padding: 4px 0;
+      user-select: none;
+    }
+
+    .thinking-block summary:hover { color: #a98edb; }
+
+    .thinking-steps {
+      margin-top: 4px;
+      padding: 8px 12px;
+      background: #111128;
+      border: 1px solid #2a2a4a;
+      border-radius: 6px;
+      max-height: 300px;
+      overflow-y: auto;
+    }
+
+    .tool-step {
+      padding: 4px 0;
+      border-bottom: 1px solid #1e1e3a;
+      font-family: monospace;
+      font-size: 11px;
+      color: #aaa;
+    }
+
+    .tool-step:last-child { border-bottom: none; }
+
+    .tool-step .tool-name {
+      color: #a98edb;
+      font-weight: 600;
+    }
+
+    .tool-step .tool-args {
+      color: #6b8fb5;
+      margin-left: 8px;
+    }
+
+    .tool-step .tool-result {
+      color: #6b9b6b;
+      display: block;
+      margin-top: 2px;
+      white-space: pre-wrap;
+      max-height: 100px;
+      overflow-y: auto;
+    }
+
+    /* Token usage badge */
+    .usage-badge {
+      align-self: flex-start;
+      font-size: 11px;
+      color: #666;
+      padding: 2px 8px;
+      font-family: monospace;
     }
 
     #input-area {
@@ -117,6 +181,12 @@
 
     #send:hover { background: #6b44a0; }
     #send:disabled { background: #333; cursor: not-allowed; }
+
+    @keyframes pulse {
+      0%, 100% { opacity: 1; }
+      50% { opacity: 0.4; }
+    }
+    .pulsing { animation: pulse 1.5s infinite; }
   </style>
 </head>
 <body>
@@ -140,6 +210,15 @@
     const inputEl = document.getElementById('input');
     const sendBtn = document.getElementById('send');
 
+    function addElement(html, cls) {
+      const div = document.createElement('div');
+      if (cls) div.className = cls;
+      div.innerHTML = html;
+      messagesEl.appendChild(div);
+      messagesEl.scrollTop = messagesEl.scrollHeight;
+      return div;
+    }
+
     function addMessage(text, cls) {
       const div = document.createElement('div');
       div.className = 'msg ' + cls;
@@ -147,6 +226,10 @@
       messagesEl.appendChild(div);
       messagesEl.scrollTop = messagesEl.scrollHeight;
       return div;
+    }
+
+    function escapeHtml(s) {
+      return s.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
     }
 
     async function send() {
@@ -158,7 +241,39 @@
       addMessage(message, 'user');
 
       sendBtn.disabled = true;
-      const thinking = addMessage('Thinking...', 'thinking');
+      const statusEl = addMessage('Thinking...', 'thinking-status pulsing');
+
+      // Thinking block — collects tool calls
+      let thinkingEl = null;
+      let stepsEl = null;
+      let toolCount = 0;
+
+      function ensureThinkingBlock() {
+        if (thinkingEl) return;
+        thinkingEl = addElement(
+          '<details open><summary>Thinking...</summary><div class="thinking-steps"></div></details>',
+          'thinking-block'
+        );
+        stepsEl = thinkingEl.querySelector('.thinking-steps');
+      }
+
+      function addToolStep(html) {
+        ensureThinkingBlock();
+        const step = document.createElement('div');
+        step.className = 'tool-step';
+        step.innerHTML = html;
+        stepsEl.appendChild(step);
+        messagesEl.scrollTop = messagesEl.scrollHeight;
+      }
+
+      function updateThinkingSummary() {
+        if (!thinkingEl) return;
+        const summary = thinkingEl.querySelector('summary');
+        summary.textContent = `Thinking (${toolCount} tool call${toolCount !== 1 ? 's' : ''})`;
+      }
+
+      // Track active tool calls to match start/end
+      const activeTools = new Map();
 
       try {
         const res = await fetch('/chat', {
@@ -167,18 +282,83 @@
           body: JSON.stringify({ message, sessionId }),
         });
 
-        thinking.remove();
-
         if (!res.ok) {
+          statusEl.remove();
           const err = await res.json().catch(() => ({ error: res.statusText }));
           addMessage('Error: ' + (err.error || res.statusText), 'error');
           return;
         }
 
-        const data = await res.json();
-        addMessage(data.response, 'agent');
+        // Read SSE stream
+        const reader = res.body.getReader();
+        const decoder = new TextDecoder();
+        let buffer = '';
+
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+
+          buffer += decoder.decode(value, { stream: true });
+          const lines = buffer.split('\n');
+          buffer = lines.pop(); // keep incomplete line in buffer
+
+          for (const line of lines) {
+            if (!line.startsWith('data: ')) continue;
+            const data = line.slice(6);
+            if (data === '[DONE]') continue;
+
+            let event;
+            try { event = JSON.parse(data); } catch { continue; }
+
+            if (event.type === 'tool_start') {
+              toolCount++;
+              const argsStr = event.args ? JSON.stringify(event.args) : '';
+              const shortArgs = argsStr.length > 120 ? argsStr.slice(0, 120) + '...' : argsStr;
+              addToolStep(
+                `<span class="tool-name">${escapeHtml(event.name || '?')}</span>` +
+                `<span class="tool-args">${escapeHtml(shortArgs)}</span>`
+              );
+              statusEl.textContent = `Calling ${event.name}...`;
+              updateThinkingSummary();
+            } else if (event.type === 'tool_end') {
+              const result = event.result || '';
+              const shortResult = result.length > 300 ? result.slice(0, 300) + '...' : result;
+              // Append result to the last tool step
+              if (stepsEl && stepsEl.lastChild) {
+                const resultSpan = document.createElement('span');
+                resultSpan.className = 'tool-result';
+                resultSpan.textContent = shortResult;
+                stepsEl.lastChild.appendChild(resultSpan);
+              }
+              statusEl.textContent = 'Thinking...';
+              messagesEl.scrollTop = messagesEl.scrollHeight;
+            } else if (event.type === 'response') {
+              statusEl.remove();
+              addMessage(event.text || '(empty response)', 'agent');
+            } else if (event.type === 'usage') {
+              const t = event.tokens || {};
+              addElement(
+                `tokens: ${(t.input||0).toLocaleString()} in / ${(t.output||0).toLocaleString()} out / ${(t.total||0).toLocaleString()} total`,
+                'usage-badge'
+              );
+            } else if (event.type === 'error') {
+              statusEl.remove();
+              addMessage('Error: ' + (event.message || 'Unknown error'), 'error');
+            }
+          }
+        }
+
+        // If status element is still there (no response event), remove it
+        if (statusEl.parentNode) statusEl.remove();
+
+        // Collapse thinking block after response arrives
+        if (thinkingEl) {
+          const details = thinkingEl.querySelector('details');
+          if (details) details.open = false;
+        }
+
       } catch (err) {
-        thinking.remove();
+        if (statusEl.parentNode) statusEl.remove();
         addMessage('Network error: ' + err.message, 'error');
       } finally {
         sendBtn.disabled = false;

--- a/tests/listener.test.ts
+++ b/tests/listener.test.ts
@@ -22,11 +22,12 @@ vi.mock('../src/reviewer-agent.js', () => ({
 
 vi.mock('../src/chat-agent.js', () => ({
   chat: vi.fn().mockResolvedValue({ response: 'mock response', sessionId: 'test-session' }),
+  chatStream: vi.fn(),
 }));
 
 import { runAnalyzeSingle } from '../src/core.js';
 import { runReviewSingle } from '../src/reviewer-agent.js';
-import { chat } from '../src/chat-agent.js';
+import { chat, chatStream } from '../src/chat-agent.js';
 
 // ── verifySignature ──────────────────────────────────────────────────────────
 
@@ -683,10 +684,32 @@ describe('createDialogApp', () => {
     });
   }
 
+  /** Helper: create a mock async generator that yields the given events. */
+  function mockStream(events: any[]) {
+    return async function* () {
+      for (const e of events) yield e;
+    };
+  }
+
+  /** Parse SSE body string into an array of parsed event objects. */
+  function parseSSE(raw: string): any[] {
+    return raw
+      .split('\n')
+      .filter((l: string) => l.startsWith('data: '))
+      .map((l: string) => l.slice(6))
+      .filter((d: string) => d !== '[DONE]')
+      .map((d: string) => { try { return JSON.parse(d); } catch { return d; } });
+  }
+
   beforeEach(() => {
     vi.spyOn(console, 'log').mockImplementation(() => {});
     vi.spyOn(console, 'error').mockImplementation(() => {});
-    vi.mocked(chat).mockReset().mockResolvedValue({ response: 'Hello from agent', sessionId: 'sess-1' });
+    vi.mocked(chatStream).mockReset().mockImplementation(
+      mockStream([
+        { type: 'response', text: 'Hello from agent' },
+        { type: 'usage', tokens: { input: 10, output: 5, total: 15 } },
+      ]) as any,
+    );
   });
 
   afterEach(() => {
@@ -709,16 +732,43 @@ describe('createDialogApp', () => {
     expect(res.headers['content-type']).toContain('text/html');
   });
 
-  it('POST /chat returns agent response for valid message', async () => {
+  it('POST /chat streams SSE events for valid message', async () => {
     const app = createDialogApp(mockConfig);
     const res = await inject(app, 'POST', '/chat', {
       body: JSON.stringify({ message: 'What does this project do?', sessionId: 'test-session' }),
     });
 
     expect(res.status).toBe(200);
-    expect(res.body.response).toBe('Hello from agent');
-    expect(res.body.sessionId).toBe('sess-1');
-    expect(chat).toHaveBeenCalledWith(mockConfig, 'What does this project do?', 'test-session');
+    expect(res.headers['content-type']).toContain('text/event-stream');
+
+    const events = parseSSE(res.body);
+    expect(events).toEqual([
+      { type: 'response', text: 'Hello from agent' },
+      { type: 'usage', tokens: { input: 10, output: 5, total: 15 } },
+    ]);
+    expect(chatStream).toHaveBeenCalledWith(mockConfig, 'What does this project do?', 'test-session');
+  });
+
+  it('POST /chat streams tool calls in thinking events', async () => {
+    vi.mocked(chatStream).mockImplementation(
+      mockStream([
+        { type: 'tool_start', name: 'list_repo_files', args: { path: 'src' } },
+        { type: 'tool_end', name: 'list_repo_files', result: 'cli.ts\ncore.ts' },
+        { type: 'response', text: 'Found 2 files.' },
+        { type: 'usage', tokens: { input: 100, output: 20, total: 120 } },
+      ]) as any,
+    );
+
+    const app = createDialogApp(mockConfig);
+    const res = await inject(app, 'POST', '/chat', {
+      body: JSON.stringify({ message: 'list files', sessionId: 's1' }),
+    });
+
+    const events = parseSSE(res.body);
+    expect(events[0]).toEqual({ type: 'tool_start', name: 'list_repo_files', args: { path: 'src' } });
+    expect(events[1]).toEqual({ type: 'tool_end', name: 'list_repo_files', result: 'cli.ts\ncore.ts' });
+    expect(events[2]).toEqual({ type: 'response', text: 'Found 2 files.' });
+    expect(events[3].type).toBe('usage');
   });
 
   it('POST /chat returns 400 when message is missing', async () => {
@@ -747,20 +797,22 @@ describe('createDialogApp', () => {
     });
 
     expect(res.status).toBe(200);
-    // chat() should have been called with some generated UUID
-    expect(chat).toHaveBeenCalledWith(mockConfig, 'Hello', expect.any(String));
+    expect(chatStream).toHaveBeenCalledWith(mockConfig, 'Hello', expect.any(String));
   });
 
-  it('POST /chat returns 500 when chat agent throws', async () => {
-    vi.mocked(chat).mockRejectedValueOnce(new Error('LLM down'));
+  it('POST /chat streams error event when chatStream throws', async () => {
+    vi.mocked(chatStream).mockImplementation(() => {
+      throw new Error('LLM down');
+    });
 
     const app = createDialogApp(mockConfig);
     const res = await inject(app, 'POST', '/chat', {
       body: JSON.stringify({ message: 'Hello', sessionId: 's1' }),
     });
 
-    expect(res.status).toBe(500);
-    expect(res.body.error).toBe('Chat agent failed');
+    expect(res.status).toBe(200);
+    const events = parseSSE(res.body);
+    expect(events).toContainEqual({ type: 'error', message: 'Chat agent failed' });
     expect(console.error).toHaveBeenCalledWith(
       expect.stringContaining('Error for session s1'),
       expect.any(Error),


### PR DESCRIPTION
## Summary
- **SSE streaming**: `/chat` endpoint now streams events in real-time instead of returning a single JSON response
- **Thinking display**: Collapsible block in the dialog UI showing each tool call (name, args, result) as they happen
- **Token usage**: Badge showing input/output/total token counts after each response
- **Better error visibility**: Errors stream to the UI immediately instead of hanging

Fixes #51

## Test plan
- [x] 1 new test for tool call streaming events
- [x] All 267 tests pass
- [x] Manual testing: dialog UI shows thinking block, token usage, handles errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)